### PR TITLE
fix: extend refresh token lifetime to 6 months

### DIFF
--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -46,7 +46,7 @@ const envSchema = z.object({
     JWT_ACCESS_SECRET: z.string().min(32),
     JWT_REFRESH_SECRET: z.string().min(32),
     JWT_ACCESS_EXPIRES_IN: z.string().default('15m'),
-    JWT_REFRESH_EXPIRES_IN: z.string().default('7d'),
+    JWT_REFRESH_EXPIRES_IN: z.string().default('180d'),
 
     // Encryption
     ENCRYPTION_KEY: z.string().min(32),

--- a/server/src/features/auth/controller.ts
+++ b/server/src/features/auth/controller.ts
@@ -99,7 +99,7 @@ export const authController = {
                 httpOnly: true,
                 secure: config.isProd,
                 sameSite: 'lax',
-                maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
+                maxAge: 180 * 24 * 60 * 60 * 1000, // 180 days
             });
 
             // Strip refreshToken from response body (it's already in HttpOnly cookie)
@@ -177,7 +177,7 @@ export const authController = {
                 httpOnly: true,
                 secure: config.isProd,
                 sameSite: 'lax',
-                maxAge: 7 * 24 * 60 * 60 * 1000,
+                maxAge: 180 * 24 * 60 * 60 * 1000, // 180 days
             });
 
             res.json(result);

--- a/server/src/features/auth/service.ts
+++ b/server/src/features/auth/service.ts
@@ -245,7 +245,7 @@ export const authService = {
         // Hash refresh token for storage
         const tokenHash = await bcrypt.hash(refreshToken, 10);
         const tokenExpiresAt = new Date();
-        tokenExpiresAt.setDate(tokenExpiresAt.getDate() + 7);
+        tokenExpiresAt.setDate(tokenExpiresAt.getDate() + 180);
 
         // Execute transaction
         try {
@@ -337,7 +337,7 @@ export const authService = {
         // Store new refresh token
         const tokenHash = await bcrypt.hash(newRefreshToken, 10);
         const expiresAt = new Date();
-        expiresAt.setDate(expiresAt.getDate() + 7);
+        expiresAt.setDate(expiresAt.getDate() + 180);
         await authRepository.createRefreshToken(user.id, tokenHash, expiresAt);
 
         return {


### PR DESCRIPTION
## Summary
- Extended refresh token lifetime from 7 days to 180 days across all 5 locations (JWT config default, cookie maxAge on verify2FA and refresh endpoints, DB token expiry on verify2FA and refresh service)
- Users will stay authenticated on the same device for 6 months without needing to re-login
- Access tokens remain short-lived (15 min) for security — auto-refreshed transparently via the httpOnly refresh cookie

## Test plan
- [ ] Login and verify refresh token cookie has ~180 day expiry (check DevTools > Application > Cookies)
- [ ] Close browser, reopen — session should restore without re-login
- [ ] Wait for access token to expire (15 min), verify auto-refresh works seamlessly
- [ ] Verify logout still clears tokens and requires re-login

🤖 Generated with [Claude Code](https://claude.com/claude-code)