### PR TITLE
feat: PWA install support + browser password manager

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,8 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/icon.ico" />
+    <link rel="icon" type="image/x-icon" href="/icon.ico" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#1976d2" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="electis Space" />
+    <link rel="apple-touch-icon" href="/logos/AppIcon.png" />
     <!-- Google Fonts: Assistant for Hebrew -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,23 @@
+{
+  "name": "electis Space",
+  "short_name": "electisSpace",
+  "description": "ESL Management System - electis Space",
+  "start_url": "./",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#1976d2",
+  "orientation": "any",
+  "icons": [
+    {
+      "src": "logos/AppIcon.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "icon.ico",
+      "sizes": "48x48",
+      "type": "image/x-icon"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,56 @@
+/**
+ * Service Worker for electis Space PWA
+ * Provides app installability and basic offline caching of app shell.
+ */
+
+const CACHE_NAME = 'electis-space-v1';
+
+// Cache app shell on install
+self.addEventListener('install', (event) => {
+  self.skipWaiting();
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) =>
+      cache.addAll(['./', './index.html'])
+    )
+  );
+});
+
+// Clean up old caches on activate
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((key) => key !== CACHE_NAME)
+          .map((key) => caches.delete(key))
+      )
+    ).then(() => self.clients.claim())
+  );
+});
+
+// Network-first strategy: try network, fall back to cache
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+
+  // Skip non-GET, API calls, and SSE connections
+  if (
+    request.method !== 'GET' ||
+    request.url.includes('/api/') ||
+    request.url.includes('/events')
+  ) {
+    return;
+  }
+
+  event.respondWith(
+    fetch(request)
+      .then((response) => {
+        // Cache successful responses for navigation requests
+        if (response.ok && request.mode === 'navigate') {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
+        }
+        return response;
+      })
+      .catch(() => caches.match(request))
+  );
+});

--- a/src/features/auth/presentation/LoginPage.tsx
+++ b/src/features/auth/presentation/LoginPage.tsx
@@ -214,6 +214,7 @@ export function LoginPage() {
                         <form onSubmit={handleSubmit}>
                             <TextField
                                 fullWidth
+                                name="email"
                                 label={t('login.email', 'Email Address')}
                                 type="email"
                                 value={email}
@@ -231,6 +232,7 @@ export function LoginPage() {
                             <Box sx={{ display: 'flex', flexDirection: isRtl ? 'row-reverse' : 'row', gap: 1, mb: 4 }}>
                                 <TextField
                                     fullWidth
+                                    name="password"
                                     label={t('login.password', 'Password')}
                                     type={showPassword ? 'text' : 'password'}
                                     value={password}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,3 +12,12 @@ i18nReady.then(() => {
     </StrictMode>,
   )
 })
+
+// Register service worker for PWA install support
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('./sw.js').catch(() => {
+      // SW registration failed — app works fine without it
+    })
+  })
+}


### PR DESCRIPTION
## Summary
- **Password manager:** Added `name="email"` and `name="password"` attributes to login form TextFields — browsers now recognize the fields and offer to save/autofill credentials
- **PWA install:** Added `manifest.webmanifest`, service worker, and meta tags so users can "Add to Home Screen" / "Install App" from Chrome/Edge/Safari. The app runs in standalone mode (no browser chrome)
- **Service worker:** Network-first strategy — always tries network first, falls back to cached app shell if offline. API calls and SSE are excluded from caching

## Test plan
- [ ] Login with credentials — browser should offer to save password
- [ ] On next visit, browser should autofill the saved credentials
- [ ] In Chrome/Edge, verify the "Install" icon appears in the address bar
- [ ] Click install — app opens in standalone window without browser chrome
- [ ] Verify the app works normally after installing as PWA
- [ ] Verify service worker registers (DevTools > Application > Service Workers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)