### PR TITLE
fix: store switch no longer logs out user

### DIFF
--- a/src/shared/infrastructure/services/authService.ts
+++ b/src/shared/infrastructure/services/authService.ts
@@ -199,14 +199,18 @@ export const authService = {
     },
 
     /**
-     * Update user's active company/store context
+     * Update user's active company/store context.
+     * The PATCH endpoint only returns { activeCompanyId, activeStoreId },
+     * so we follow up with /auth/me to get the full user object.
      */
     updateContext: async (activeCompanyId?: string | null, activeStoreId?: string | null): Promise<{ user: User }> => {
-        const response = await api.patch<{ user: User }>('/users/me/context', {
+        await api.patch('/users/me/context', {
             activeCompanyId,
             activeStoreId,
         });
-        return response.data;
+        // Fetch full user object after context update
+        const meResponse = await api.get<{ user: User }>('/auth/me');
+        return meResponse.data;
     },
 
     /**


### PR DESCRIPTION
## Summary
- **Root cause found:** `PATCH /users/me/context` returns `{ activeCompanyId, activeStoreId }` — no `user` object. But `authStore.setActiveStore()` destructures `const { user } = response`, getting `undefined`, which wipes auth state and causes immediate logout.
- **Fix:** `authService.updateContext()` now calls `/auth/me` after the PATCH to fetch the full user object. This is a 1-file, 4-line fix that resolves the store/company switch logout for all three switch functions.

## Why this was hard to find
The TypeScript type said `Promise<{ user: User }>` but the actual server response was `{ activeCompanyId, activeStoreId }`. No runtime error — `user` silently became `undefined`, and setting `user: undefined` in Zustand caused cascading auth failures.

## Test plan
- [ ] Login as admin with access to multiple stores
- [ ] Switch stores via the CompanyStoreSelector dropdown
- [ ] Verify: "Switching store..." loading screen appears, then new store data loads
- [ ] Verify: NO logout, NO login page, NO need to refresh
- [ ] Switch back to original store — should work cleanly
- [ ] Switch companies — should also work without logout
- [ ] Verify: after switching, all tabs (Spaces, Conference, Labels, etc.) show correct data

🤖 Generated with [Claude Code](https://claude.com/claude-code)