### PR TITLE
ui: bigger mobile action buttons and people toolbar layout

### DIFF
--- a/src/features/conference/presentation/ConferencePage.tsx
+++ b/src/features/conference/presentation/ConferencePage.tsx
@@ -549,9 +549,18 @@ export function ConferencePage() {
                     color="primary"
                     variant="extended"
                     onClick={handleAdd}
-                    sx={{ position: 'fixed', bottom: 24, right: 24, zIndex: 1050 }}
+                    sx={{
+                        position: 'fixed',
+                        bottom: 24,
+                        right: 24,
+                        zIndex: 1050,
+                        height: 64,
+                        px: 3,
+                        fontSize: '1.1rem',
+                        fontWeight: 600,
+                    }}
                 >
-                    <AddIcon sx={{ mr: 1 }} />
+                    <AddIcon sx={{ mr: 1, fontSize: '1.5rem' }} />
                     {t('conference.addRoom')}
                 </Fab>
             )}

--- a/src/features/dashboard/components/QuickActionsPanel.tsx
+++ b/src/features/dashboard/components/QuickActionsPanel.tsx
@@ -104,9 +104,9 @@ export function QuickActionsPanel({
                                         textTransform: 'none',
                                         fontWeight: 700,
                                         px: 4,
-                                        py: 2,
-                                        fontSize: '1.2rem',
-                                        minHeight: 60,
+                                        py: 2.5,
+                                        fontSize: '1.3rem',
+                                        minHeight: 72,
                                         ...(action.variant === 'contained'
                                             ? {
                                                   boxShadow: (theme: any) =>
@@ -137,8 +137,9 @@ export function QuickActionsPanel({
                         sx={{
                             transition: 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
                             transform: open ? 'rotate(45deg)' : 'none',
-                            width: 64,
-                            height: 64,
+                            width: 72,
+                            height: 72,
+                            '& .MuiSvgIcon-root': { fontSize: '2rem' },
                         }}
                     >
                         {open ? <CloseIcon /> : <AddIcon />}

--- a/src/features/labels/presentation/LabelsPage.tsx
+++ b/src/features/labels/presentation/LabelsPage.tsx
@@ -747,9 +747,9 @@ export function LabelsPage() {
                                         textTransform: 'none',
                                         fontWeight: 700,
                                         px: 4,
-                                        py: 2,
-                                        fontSize: '1.2rem',
-                                        minHeight: 60,
+                                        py: 2.5,
+                                        fontSize: '1.3rem',
+                                        minHeight: 72,
                                         boxShadow: (theme: any) =>
                                             `0 4px 14px ${alpha(theme.palette.primary.main, 0.35)}`,
                                     }}
@@ -782,9 +782,9 @@ export function LabelsPage() {
                                         textTransform: 'none',
                                         fontWeight: 700,
                                         px: 4,
-                                        py: 2,
-                                        fontSize: '1.2rem',
-                                        minHeight: 60,
+                                        py: 2.5,
+                                        fontSize: '1.3rem',
+                                        minHeight: 72,
                                         borderColor: (theme: any) => alpha(theme.palette.primary.main, 0.3),
                                         bgcolor: (theme: any) => alpha(theme.palette.background.paper, 0.85),
                                         backdropFilter: 'blur(12px)',
@@ -807,8 +807,9 @@ export function LabelsPage() {
                             sx={{
                                 transition: 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
                                 transform: speedDialOpen ? 'rotate(45deg)' : 'none',
-                                width: 64,
-                                height: 64,
+                                width: 72,
+                                height: 72,
+                                '& .MuiSvgIcon-root': { fontSize: '2rem' },
                             }}
                         >
                             {speedDialOpen ? <CloseIcon /> : <AddIcon />}

--- a/src/features/people/presentation/PeopleManagerView.tsx
+++ b/src/features/people/presentation/PeopleManagerView.tsx
@@ -533,9 +533,13 @@ export function PeopleManagerView() {
                         bottom: 24,
                         right: 24,
                         zIndex: 1050,
+                        height: 64,
+                        px: 3,
+                        fontSize: '1.1rem',
+                        fontWeight: 600,
                     }}
                 >
-                    <AddIcon sx={{ mr: 1 }} />
+                    <AddIcon sx={{ mr: 1, fontSize: '1.5rem' }} />
                     {t('people.addPerson')}
                 </Fab>
             )}

--- a/src/features/people/presentation/components/PeopleToolbar.tsx
+++ b/src/features/people/presentation/components/PeopleToolbar.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography, Button, Stack, Tooltip, IconButton } from '@mui/material';
+import { Box, Typography, Button, Stack } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import UploadFileIcon from '@mui/icons-material/UploadFile';
 import { useTranslation } from 'react-i18next';
@@ -10,7 +10,7 @@ interface PeopleToolbarProps {
 }
 
 /**
- * PeopleToolbar - Header section with title and primary actions
+ * PeopleToolbar - Header section with title and primary actions below it
  * Active list name is shown in PeopleListPanel instead.
  */
 export function PeopleToolbar({
@@ -21,14 +21,9 @@ export function PeopleToolbar({
     const { t } = useTranslation();
 
     return (
-        <Stack
-            direction="row"
-            justifyContent="space-between"
-            alignItems="center"
-            gap={1}
-            sx={{ mb: { xs: 2, sm: 3 } }}
-        >
-            <Box sx={{ minWidth: 0 }}>
+        <Box sx={{ mb: { xs: 2, sm: 3 } }}>
+            {/* Title row */}
+            <Box sx={{ mb: 1 }}>
                 <Typography variant="h4" sx={{ fontWeight: 500, whiteSpace: 'nowrap', fontSize: { xs: '1.25rem', sm: '2rem' }, mb: 0.5 }}>
                     {t('people.title')}
                 </Typography>
@@ -36,36 +31,35 @@ export function PeopleToolbar({
                     {t('people.total')} - {totalPeople}
                 </Typography>
             </Box>
-            <Stack direction="row" gap={{ xs: 0.5, sm: 2 }} flexShrink={0}>
-                {/* Add Person — hidden on mobile (replaced by FAB) */}
+
+            {/* Action buttons row — under the header */}
+            <Stack direction="row" gap={1.5} flexWrap="wrap">
                 <Button
                     variant="contained"
                     startIcon={<AddIcon />}
                     onClick={onAddPerson}
-                    size="small"
-                    sx={{ whiteSpace: 'nowrap', display: { xs: 'none', md: 'inline-flex' } }}
+                    sx={{
+                        whiteSpace: 'nowrap',
+                        display: { xs: 'none', md: 'inline-flex' },
+                        minHeight: 44,
+                        px: 3,
+                    }}
                 >
                     {t('people.addPerson')}
                 </Button>
                 <Button
-                    variant="text"
+                    variant="outlined"
                     startIcon={<UploadFileIcon />}
                     onClick={onUploadCSV}
-                    size="small"
-                    sx={{ whiteSpace: 'nowrap', display: { xs: 'none', sm: 'inline-flex' } }}
+                    sx={{
+                        whiteSpace: 'nowrap',
+                        minHeight: { xs: 44, md: 44 },
+                        px: { xs: 2, sm: 3 },
+                    }}
                 >
                     {t('people.uploadCSV')}
                 </Button>
-                <Tooltip title={t('people.uploadCSV')}>
-                    <IconButton
-                        onClick={onUploadCSV}
-                        size="small"
-                        sx={{ display: { xs: 'inline-flex', sm: 'none' } }}
-                    >
-                        <UploadFileIcon />
-                    </IconButton>
-                </Tooltip>
             </Stack>
-        </Stack>
+        </Box>
     );
 }

--- a/src/features/space/presentation/SpacesManagementView.tsx
+++ b/src/features/space/presentation/SpacesManagementView.tsx
@@ -718,9 +718,18 @@ export function SpacesManagementView() {
                     color="primary"
                     variant="extended"
                     onClick={handleAdd}
-                    sx={{ position: 'fixed', bottom: 24, right: 24, zIndex: 1050 }}
+                    sx={{
+                        position: 'fixed',
+                        bottom: 24,
+                        right: 24,
+                        zIndex: 1050,
+                        height: 64,
+                        px: 3,
+                        fontSize: '1.1rem',
+                        fontWeight: 600,
+                    }}
                 >
-                    <AddIcon sx={{ mr: 1 }} />
+                    <AddIcon sx={{ mr: 1, fontSize: '1.5rem' }} />
                     {getLabel('add')}
                 </Fab>
             )}


### PR DESCRIPTION
## Summary
- **People Manager toolbar**: Moved Add Person + Upload CSV buttons to a row *under* the header title (was crammed next to it). Removed `size="small"`, buttons are now proper default size with `minHeight: 44`. Upload CSV shows as full text button on all screen sizes (was icon-only on mobile).
- **All mobile FABs** (Spaces, Conference, People): Increased to `height: 64`, `fontSize: 1.1rem`, icon `1.5rem`
- **Speed dial FABs** (Dashboard, Labels): Increased from 64x64 to 72x72 with 2rem icons
- **Speed dial action buttons** (Dashboard, Labels): Increased from `minHeight: 60` to `72`, font from `1.2rem` to `1.3rem`

## Test plan
- [ ] Check People Manager page on mobile — buttons visible under title, Upload CSV is a full button
- [ ] Check all mobile FABs are visibly larger (Spaces, Conference, People pages)
- [ ] Check Dashboard speed dial: FAB is bigger, action buttons when expanded are bigger
- [ ] Check Labels speed dial: same pattern, bigger FAB and action buttons
- [ ] Verify desktop layout is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)