### PR TITLE
fix: allow platform admins to access sync endpoints

### DIFF
--- a/server/src/features/sync/controller.ts
+++ b/server/src/features/sync/controller.ts
@@ -17,6 +17,7 @@ import { aimsGateway } from '../../shared/infrastructure/services/aimsGateway.js
 function getUserContext(req: Request): SyncUserContext {
     return {
         id: req.user!.id,
+        globalRole: req.user?.globalRole,
         stores: req.user?.stores?.map(s => ({ id: s.id })),
     };
 }
@@ -211,7 +212,7 @@ export const syncController = {
 
             const user = getUserContext(req);
             const storeIds = user.stores?.map(s => s.id) || [];
-            if (!storeIds.includes(storeId)) return next(forbidden('Access denied to this store'));
+            if (user.globalRole !== 'PLATFORM_ADMIN' && !storeIds.includes(storeId)) return next(forbidden('Access denied to this store'));
 
             const start = Date.now();
             const connected = await aimsGateway.checkHealth(storeId);
@@ -234,7 +235,7 @@ export const syncController = {
 
             const user = getUserContext(req);
             const storeIds = user.stores?.map(s => s.id) || [];
-            if (!storeIds.includes(storeId)) return next(forbidden('Access denied to this store'));
+            if (user.globalRole !== 'PLATFORM_ADMIN' && !storeIds.includes(storeId)) return next(forbidden('Access denied to this store'));
 
             const storeConfig = await aimsGateway.getStoreConfig(storeId);
             if (!storeConfig) {
@@ -261,7 +262,7 @@ export const syncController = {
 
             const user = getUserContext(req);
             const storeIds = user.stores?.map(s => s.id) || [];
-            if (!storeIds.includes(storeId)) return next(forbidden('Access denied to this store'));
+            if (user.globalRole !== 'PLATFORM_ADMIN' && !storeIds.includes(storeId)) return next(forbidden('Access denied to this store'));
 
             const storeConfig = await aimsGateway.getStoreConfig(storeId);
             if (storeConfig) {

--- a/server/src/features/sync/repository.ts
+++ b/server/src/features/sync/repository.ts
@@ -87,12 +87,12 @@ export const syncRepository = {
     /**
      * List queue items
      */
-    async listQueueItems(storeIds: string[], storeId?: string, status?: string) {
+    async listQueueItems(storeIds: string[] | undefined, storeId?: string, status?: string) {
         const whereClause: any = {};
-        
+
         if (storeId) {
             whereClause.storeId = storeId;
-        } else {
+        } else if (storeIds) {
             whereClause.storeId = { in: storeIds };
         }
         
@@ -113,14 +113,12 @@ export const syncRepository = {
     /**
      * Get failed item by ID
      */
-    async getFailedItem(id: string, storeIds: string[]) {
-        return prisma.syncQueueItem.findFirst({
-            where: {
-                id,
-                storeId: { in: storeIds },
-                status: 'FAILED',
-            },
-        });
+    async getFailedItem(id: string, storeIds: string[] | undefined) {
+        const where: any = { id, status: 'FAILED' };
+        if (storeIds) {
+            where.storeId = { in: storeIds };
+        }
+        return prisma.syncQueueItem.findFirst({ where });
     },
 
     /**

--- a/server/src/features/sync/types.ts
+++ b/server/src/features/sync/types.ts
@@ -110,5 +110,6 @@ export interface StoreSyncStatusResponse {
 
 export interface SyncUserContext {
     id: string;
+    globalRole?: string | null;
     stores?: Array<{ id: string }>;
 }


### PR DESCRIPTION
## Summary
- Platform admins (`globalRole=PLATFORM_ADMIN`) without explicit `UserStore` entries got empty `stores[]` from JWT, causing all sync access checks to throw FORBIDDEN
- This made AIMS appear permanently disconnected in the sync status indicator
- Fixed `validateStoreAccess` to check for platform admin role before checking store list
- Updated all sync controller/service/repository methods to handle platform admin access

## Test plan
- [ ] Login as platform admin, verify sync indicator shows correct AIMS connection status
- [ ] Verify pull/push/full sync works for platform admin
- [ ] Verify regular users still only access their assigned stores

🤖 Generated with [Claude Code](https://claude.com/claude-code)