### PR TITLE
fix: login redirect, native barcode scanner, CSP/SW fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <link rel="manifest" href="manifest.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#1976d2" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="electis Space" />
     <link rel="apple-touch-icon" href="logos/AppIcon.png" />

--- a/public/sw.js
+++ b/public/sw.js
@@ -41,6 +41,11 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
+  // Skip cross-origin requests (fonts, analytics, etc.)
+  if (new URL(request.url).origin !== self.location.origin) {
+    return;
+  }
+
   event.respondWith(
     fetch(request)
       .then((response) => {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -45,7 +45,19 @@ app.use(requestIdMiddleware);
 // ======================
 // Security Middleware
 // ======================
-app.use(helmet());
+app.use(helmet({
+    contentSecurityPolicy: {
+        directives: {
+            defaultSrc: ["'self'"],
+            scriptSrc: ["'self'"],
+            styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
+            fontSrc: ["'self'", "https://fonts.gstatic.com"],
+            imgSrc: ["'self'", "data:", "blob:"],
+            connectSrc: ["'self'", "https://fonts.googleapis.com", "https://fonts.gstatic.com"],
+            mediaSrc: ["'self'", "blob:"],
+        },
+    },
+}));
 app.use(
     cors({
         origin: config.corsOrigins,

--- a/src/features/auth/presentation/LoginPage.tsx
+++ b/src/features/auth/presentation/LoginPage.tsx
@@ -28,7 +28,7 @@ export function LoginPage() {
     const navigate = useNavigate();
     const theme = useTheme();
     const isRtl = theme.direction === 'rtl';
-    const { login, verify2FA, resendCode, isLoading, error, clearError, pendingEmail } = useAuthStore();
+    const { login, verify2FA, resendCode, isLoading, error, clearError, pendingEmail, isAuthenticated, isInitialized } = useAuthStore();
 
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
@@ -36,6 +36,13 @@ export function LoginPage() {
     const [showPassword, setShowPassword] = useState(false);
     const [showVerification, setShowVerification] = useState(false);
     const autoSubmitRef = useRef(false);
+
+    // Redirect to dashboard if already authenticated
+    useEffect(() => {
+        if (isAuthenticated && isInitialized) {
+            navigate('/', { replace: true });
+        }
+    }, [isAuthenticated, isInitialized, navigate]);
 
     // Auto-submit OTP when 6 digits are entered
     useEffect(() => {


### PR DESCRIPTION
## Summary
- **Login redirect**: Authenticated users visiting `/#/login` are now redirected to the dashboard automatically
- **Barcode scanner**: Replaced `window.prompt()` stub with native `BarcodeDetector` API — real-time camera scanning with auto-detection (code_128, ean_13, ean_8, qr_code, code_39)
- **Mobile scanner layout**: Fullscreen dialog uses full width (no `maxWidth: 400`), portrait `3/4` aspect ratio, and 80% scan overlay
- **Service worker**: Cross-origin requests (Google Fonts, etc.) are now skipped in the SW fetch handler
- **Helmet CSP**: Configured explicit directives allowing Google Fonts (`styleSrc`, `fontSrc`, `connectSrc`) plus `data:`/`blob:` for images and media
- **Meta tag**: Replaced deprecated `apple-mobile-web-app-capable` with `mobile-web-app-capable`

## Test plan
- [ ] Navigate to `/#/login` while authenticated — should redirect to dashboard
- [ ] Labels page → link label → camera mode → point at barcode → auto-detects and fills code
- [ ] On mobile, scanner dialog is fullscreen with large video area, no wasted space
- [ ] No CSP errors in console for Google Fonts or sw.js
- [ ] No `apple-mobile-web-app-capable` deprecation warning in Lighthouse

🤖 Generated with [Claude Code](https://claude.com/claude-code)