### PR TITLE
Split client & server into separate Docker containers

### DIFF
--- a/.github/workflows/deploy-ubuntu.yml
+++ b/.github/workflows/deploy-ubuntu.yml
@@ -30,10 +30,6 @@ jobs:
             git remote set-url origin "https://x-access-token:${GH_PAT}@github.com/AvivElectis/electisSpace.git"
             git pull origin main
 
-            echo "=== Cleaning up old client-build container ==="
-            docker rm -f electisspace-client-build 2>/dev/null || true
-            docker volume rm electisspace-frontend-dist 2>/dev/null || true
-
             echo "=== Building containers ==="
             docker compose -f docker-compose.infra.yml -f docker-compose.app.yml build
 

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,43 @@
+# ============================================
+# electisSpace — Client (SPA + Nginx)
+# ============================================
+# Multi-stage: builds React SPA, serves with Nginx.
+# Build context must be the project root (context: .)
+# ============================================
+
+# Stage 1: Build frontend (React/Vite)
+FROM node:20-alpine AS frontend
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY src/ ./src/
+COPY public/ ./public/
+COPY index.html tsconfig*.json vite.config.ts ./
+
+ARG VITE_BASE_PATH=/
+ENV VITE_BASE_PATH=${VITE_BASE_PATH}
+RUN npm run build
+
+# Stage 2: Serve with Nginx
+FROM nginx:alpine
+
+RUN apk add --no-cache curl
+
+# Remove default nginx config
+RUN rm /etc/nginx/conf.d/default.conf
+
+# Copy custom nginx config
+COPY client/nginx.conf /etc/nginx/conf.d/default.conf
+
+# Copy built SPA
+COPY --from=frontend /app/dist /usr/share/nginx/html
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
+  CMD curl -f http://localhost:3000/ || exit 1
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,0 +1,103 @@
+upstream api_backend {
+    server electisspace-api:3000;
+    keepalive 32;
+}
+
+server {
+    listen 3000;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    client_max_body_size 10m;
+
+    # ========================
+    # Gzip compression
+    # ========================
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_min_length 256;
+    gzip_types
+        text/plain
+        text/css
+        text/javascript
+        application/javascript
+        application/json
+        application/xml
+        image/svg+xml;
+
+    # Serve pre-compressed .gz files from Vite build
+    gzip_static on;
+
+    # ========================
+    # SSE endpoints (must be before generic /api/)
+    # ========================
+    location ~ ^/api/v1/stores/.+/events$ {
+        proxy_pass http://api_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection '';
+
+        # SSE: disable buffering, long timeout
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 86400s;
+        chunked_transfer_encoding off;
+    }
+
+    # ========================
+    # API proxy
+    # ========================
+    location /api/ {
+        proxy_pass http://api_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection '';
+
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
+    # ========================
+    # Health check (proxied to Express)
+    # ========================
+    location = /health {
+        proxy_pass http://api_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection '';
+    }
+
+    # ========================
+    # Static assets (long cache)
+    # ========================
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
+    # ========================
+    # SPA fallback
+    # ========================
+    location / {
+        try_files $uri $uri/ /index.html;
+
+        # index.html should not be cached
+        location = /index.html {
+            add_header Cache-Control "no-cache";
+        }
+    }
+}

--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -1,9 +1,8 @@
 # ============================================================
 # electisSpace — Application Layer (Ubuntu Production)
 # ============================================================
-# Single server container: builds frontend + API in one image.
-# No separate client container, no shared volume.
-# NPM handles SSL termination and proxies to port 3071.
+# Two containers: Nginx (SPA + reverse proxy) + Express (API).
+# NPM → electisspace-server:3000 (Nginx) → electisspace-api:3000 (Express, internal)
 #
 # Usage:
 #   docker compose -f docker-compose.infra.yml -f docker-compose.app.yml build
@@ -13,15 +12,36 @@
 services:
 
   # ======================
-  # Server — Node.js API + Static Frontend
+  # Client — Nginx (SPA + Reverse Proxy)
+  # ======================
+  client:
+    build:
+      context: .
+      dockerfile: client/Dockerfile
+    container_name: electisspace-server
+    ports:
+      - "127.0.0.1:3071:3000"
+    depends_on:
+      server:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - global-network
+
+  # ======================
+  # Server — Node.js API
   # ======================
   server:
     build:
       context: .
       dockerfile: server/Dockerfile
-    container_name: electisspace-server
-    ports:
-      - "127.0.0.1:3071:3000"
+    container_name: electisspace-api
     env_file:
       - deploy/server.env
     environment:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,27 +1,11 @@
 # ============================================
-# electisSpace — Combined Build
+# electisSpace — Server (API Only)
 # ============================================
-# Multi-stage: builds frontend + server in one image.
+# Multi-stage: builds Express API.
 # Build context must be the project root (context: .)
 # ============================================
 
-# Stage 1: Build frontend (React/Vite)
-FROM node:20-alpine AS frontend
-
-WORKDIR /app
-
-COPY package*.json ./
-RUN npm ci
-
-COPY src/ ./src/
-COPY public/ ./public/
-COPY index.html tsconfig*.json vite.config.ts ./
-
-ARG VITE_BASE_PATH=/
-ENV VITE_BASE_PATH=${VITE_BASE_PATH}
-RUN npm run build
-
-# Stage 2: Build server (TypeScript)
+# Stage 1: Build server (TypeScript)
 FROM node:20-alpine AS server-builder
 
 WORKDIR /app
@@ -38,7 +22,7 @@ COPY server/src ./src/
 
 RUN npm run build
 
-# Stage 3: Production runtime
+# Stage 2: Production runtime
 FROM node:20-alpine AS production
 
 WORKDIR /app
@@ -64,9 +48,6 @@ COPY --from=server-builder /app/node_modules/@prisma ./node_modules/@prisma
 
 # Copy built server
 COPY --from=server-builder /app/dist ./dist
-
-# Copy built frontend
-COPY --from=frontend /app/dist ./public
 
 # Change ownership
 RUN chown -R nodejs:nodejs /app

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import path from 'path';
+import fs from 'fs';
 import cors from 'cors';
 import helmet from 'helmet';
 import compression from 'compression';
@@ -145,17 +146,19 @@ app.use(`/api/${config.apiVersion}`, apiRouter);
 // ======================
 if (!config.isDev) {
     const publicDir = path.resolve('public');
-    app.use(express.static(publicDir, {
-        maxAge: '1y',
-        immutable: true,
-        index: false,
-    }));
-    // SPA fallback: serve index.html for any unmatched GET
-    app.get('*', (_req, res) => {
-        res.sendFile(path.join(publicDir, 'index.html'), {
-            headers: { 'Cache-Control': 'no-cache' },
+    if (fs.existsSync(publicDir)) {
+        app.use(express.static(publicDir, {
+            maxAge: '1y',
+            immutable: true,
+            index: false,
+        }));
+        // SPA fallback: serve index.html for any unmatched GET
+        app.get('*', (_req, res) => {
+            res.sendFile(path.join(publicDir, 'index.html'), {
+                headers: { 'Cache-Control': 'no-cache' },
+            });
         });
-    });
+    }
 }
 
 // ======================


### PR DESCRIPTION
## Summary
- **New `client/Dockerfile`** — builds the React SPA with Vite, serves via `nginx:alpine` on port 3000
- **New `client/nginx.conf`** — SPA fallback, proxies `/api/` and `/health` to the Express API container, SSE support with `proxy_buffering off`, `gzip_static` for Vite `.gz` files
- **Simplified `server/Dockerfile`** — removed frontend build stage, now API-only (2 stages instead of 3)
- **`docker-compose.app.yml`** — two services: `client` (container: `electisspace-server`, port 3071) + `server` (container: `electisspace-api`, internal only)
- **`server/src/app.ts`** — guarded static file serving with `fs.existsSync(publicDir)` for backward compatibility
- **Deploy workflow** — removed stale `client-build` container cleanup

### Architecture
```
BEFORE:  NPM → electisspace-server:3000 → Express (API + static SPA)
AFTER:   NPM → electisspace-server:3000 → Nginx (SPA + proxy) ──/api/──→ electisspace-api:3000
```

NPM config unchanged — `electisspace-server:3000` is now the Nginx container.

## Test plan
- [ ] `docker compose -f docker-compose.infra.yml -f docker-compose.app.yml build` — both images build
- [ ] `docker compose ... up -d` — both containers start healthy
- [ ] `curl http://localhost:3071/health` → 200 (proxied through Nginx to Express)
- [ ] `curl http://localhost:3071/` → returns `index.html`
- [ ] `curl http://localhost:3071/api/v1/health` → 200 (API via proxy)
- [ ] SSE events stream correctly through Nginx
- [ ] NPM → `electisspace-server:3000` still works (container name preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)