### PR TITLE
Fix deploy path: ~/electisSpace to /opt/electisSpace

### DIFF
--- a/.github/workflows/deploy-ubuntu.yml
+++ b/.github/workflows/deploy-ubuntu.yml
@@ -24,7 +24,7 @@ jobs:
           envs: GH_PAT
           script: |
             set -e
-            cd ~/electisSpace
+            cd /opt/electisSpace
 
             echo "=== Pulling latest code ==="
             git remote set-url origin "https://x-access-token:${GH_PAT}@github.com/AvivElectis/electisSpace.git"


### PR DESCRIPTION
## Summary
- Deploy workflow failed (#18) because the project was moved from `~/electisSpace` to `/opt/electisSpace` on the server
- Updates `cd ~/electisSpace` → `cd /opt/electisSpace` in the SSH deploy script

## Test plan
- [ ] Merge → deploy workflow succeeds (SSH can `cd /opt/electisSpace`)
- [ ] Health check passes at the end of the deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)