### PR TITLE
fix: resolve console errors (health 401, stale chunks, SW CSP)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -3,7 +3,7 @@
  * Provides app installability and basic offline caching of app shell.
  */
 
-const CACHE_NAME = 'electis-space-v1';
+const CACHE_NAME = 'electis-space-v2';
 
 // Cache app shell on install
 self.addEventListener('install', (event) => {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -123,10 +123,10 @@ app.use('/health', healthRoutes);
 // ======================
 const apiRouter = express.Router();
 
+apiRouter.use('/health', healthRoutes);  // Health check (no auth) — must be before root-mounted routes
 apiRouter.use('/auth', authRoutes);
 apiRouter.use('/users', userRoutes);
 apiRouter.use('/companies', companyRoutes);
-apiRouter.use('/', storeRoutes); // Store routes mounted at root for /companies/:companyId/stores and /stores/:id
 apiRouter.use('/spaces', spaceRoutes);
 apiRouter.use('/people', peopleRoutes);
 apiRouter.use('/conference', conferenceRoutes);
@@ -136,8 +136,8 @@ apiRouter.use('/admin', adminRoutes);
 apiRouter.use('/labels', labelsRoutes);
 apiRouter.use('/people-lists', peopleListsRoutes);
 apiRouter.use('/spaces-lists', spacesListsRoutes);
+apiRouter.use('/', storeRoutes); // Store routes mounted at root — MUST be after named routes (applies authenticate globally)
 apiRouter.use('/', storeEventsRoutes);  // Mounts /stores/:storeId/events
-apiRouter.use('/health', healthRoutes);  // Also mount health inside API for proxy access
 
 app.use(`/api/${config.apiVersion}`, apiRouter);
 


### PR DESCRIPTION
## Summary
- **Health endpoint 401**: `/api/v1/health` was intercepted by store routes' `authenticate` middleware because `storeRoutes` (mounted at `/`) came before `healthRoutes` in the API router. Reordered so health and all named routes come before root-mounted routes.
- **Stale chunk 404 recovery**: After redeployments, users with cached `index.html` would get blank screens when lazy-loaded chunks (e.g. `SettingsDialog-ak2BshL7.js`) returned 404. Added auto-reload logic in `ErrorBoundary` that detects chunk load failures and reloads once.
- **Service worker CSP**: Google Fonts were blocked by stale SW CSP headers (`default-src 'self'` without `connect-src`). Bumped SW cache version to force reinstall with current helmet CSP headers.
- **403 on store endpoints**: Already fixed in prior commit on this branch — all `validateStoreAccess` functions correctly check `isPlatformAdmin` first.
- **`apple-mobile-web-app-capable` deprecation**: Already fixed in `index.html` on this branch (uses `mobile-web-app-capable`).

## Test plan
- [ ] Verify `/api/v1/health` returns 200 without auth token
- [ ] Verify authenticated API routes still work correctly
- [ ] Deploy and confirm no more CSP errors for Google Fonts in SW
- [ ] Simulate stale chunk by manually requesting a non-existent `.js` asset — should auto-reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)