### PR TITLE
fix: SW CSP font blocking and user dialog crash on edit

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -44,6 +44,21 @@ app.set('trust proxy', 1);
 app.use(requestIdMiddleware);
 
 // ======================
+// Service Worker (before helmet — SW CSP is locked at install time,
+// restrictive CSP breaks cross-origin font loading inside the SW context)
+// ======================
+if (!config.isDev) {
+    const swPath = path.resolve('public/sw.js');
+    if (fs.existsSync(swPath)) {
+        app.get('/sw.js', (_req, res) => {
+            res.sendFile(swPath, {
+                headers: { 'Cache-Control': 'no-cache', 'Content-Type': 'application/javascript' },
+            });
+        });
+    }
+}
+
+// ======================
 // Security Middleware
 // ======================
 app.use(helmet({

--- a/src/features/settings/presentation/userDialog/useUserDialogState.ts
+++ b/src/features/settings/presentation/userDialog/useUserDialogState.ts
@@ -179,7 +179,10 @@ export function useUserDialogState({ open, onSave, user, profileMode }: Params) 
     // Initialize form when dialog opens or user changes (non-profile mode)
     useEffect(() => {
         if (open && !profileMode) {
-            const userToUse = fetchedUserData || user;
+            // Edit mode: wait for fetchedUserData (correct nested shape) before initializing
+            if (user && !fetchedUserData) return;
+
+            const userToUse = fetchedUserData;
             if (userToUse) {
                 setEmail(userToUse.email);
                 setFirstName(userToUse.firstName || '');


### PR DESCRIPTION
## Summary
- **SW CSP blocking Google Fonts**: Service worker was served with helmet's restrictive CSP headers (`default-src 'self'` without `connect-src`), which got locked at install time and blocked cross-origin font loading. Now `sw.js` is served before helmet middleware with no CSP.
- **User dialog TypeError on edit**: `UsersSettingsTab` passes flat company data (`{ id, role }`) from the list endpoint, but `useUserDialogState` expected nested data (`{ company: { id }, role }`) from the detail endpoint. Accessing `.company.id` on the flat shape crashed. Fixed by waiting for `fetchedUserData` (correct shape from `GET /users/:id`) before initializing form state.

## Test plan
- [ ] Open Settings > Users, click Edit on any user — dialog should open without errors
- [ ] Verify Google Fonts load without CSP errors in the console
- [ ] Verify SW installs/updates correctly (Application > Service Workers in DevTools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)