### PR TITLE
feat: expand CompanyRole with STORE_ADMIN and STORE_VIEWER

### DIFF
--- a/server/prisma/migrations/20260219000000_add_store_roles_to_company/migration.sql
+++ b/server/prisma/migrations/20260219000000_add_store_roles_to_company/migration.sql
@@ -1,0 +1,7 @@
+-- Add STORE_ADMIN and STORE_VIEWER values to the CompanyRole enum.
+-- These allow finer-grained company-level roles:
+--   STORE_ADMIN  = all-stores admin access without company management
+--   STORE_VIEWER = per-store view-only access
+
+ALTER TYPE "CompanyRole" ADD VALUE 'STORE_ADMIN';
+ALTER TYPE "CompanyRole" ADD VALUE 'STORE_VIEWER';

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -164,6 +164,8 @@ model UserCompany {
 enum CompanyRole {
   SUPER_USER     // For PLATFORM_ADMIN - full access without restrictions
   COMPANY_ADMIN  // Can manage company settings, users, stores
+  STORE_ADMIN    // All-stores admin without company management
+  STORE_VIEWER   // Per-store view-only access
   VIEWER         // Read-only access
 }
 

--- a/server/src/features/auth/service.ts
+++ b/server/src/features/auth/service.ts
@@ -170,6 +170,7 @@ export const authService = {
         const companies = user.userCompanies.map(uc => ({
             id: uc.companyId,
             role: uc.role,
+            allStoresAccess: uc.allStoresAccess,
         }));
 
         const accessToken = jwt.sign(

--- a/server/src/features/users/controller.ts
+++ b/server/src/features/users/controller.ts
@@ -192,8 +192,9 @@ export const userController = {
                     id: uc.companyId,
                     code: uc.company.code,
                     name: uc.company.name,
+                    role: uc.role,
                     allStoresAccess: uc.allStoresAccess,
-                    isCompanyAdmin: uc.role === 'COMPANY_ADMIN',
+                    isCompanyAdmin: uc.role === 'COMPANY_ADMIN' || uc.role === 'SUPER_USER',
                 })),
                 stores: user.userStores.map((us: any) => ({
                     id: us.storeId,
@@ -420,8 +421,9 @@ export const userController = {
                 code: result.company.code,
                 name: result.company.name,
                 location: result.company.location,
+                role: result.role,
                 allStoresAccess: result.allStoresAccess,
-                isCompanyAdmin: result.role === 'COMPANY_ADMIN',
+                isCompanyAdmin: result.role === 'COMPANY_ADMIN' || result.role === 'SUPER_USER',
             });
         } catch (error: any) {
             if (error.message === 'USER_NOT_FOUND') return next(notFound('User'));
@@ -455,8 +457,9 @@ export const userController = {
                 companyId: updated.companyId,
                 code: updated.company.code,
                 name: updated.company.name,
+                role: updated.role,
                 allStoresAccess: updated.allStoresAccess,
-                isCompanyAdmin: updated.role === 'COMPANY_ADMIN',
+                isCompanyAdmin: updated.role === 'COMPANY_ADMIN' || updated.role === 'SUPER_USER',
             });
         } catch (error: any) {
             if (error.message === 'FORBIDDEN') return next(forbidden('You do not have permission to update this assignment'));

--- a/server/src/features/users/repository.ts
+++ b/server/src/features/users/repository.ts
@@ -569,6 +569,17 @@ export const userRepository = {
         });
     },
 
+    /**
+     * Batch-fetch active stores for multiple companies (for allStoresAccess expansion)
+     */
+    async findStoresByCompanyIds(companyIds: string[]) {
+        if (companyIds.length === 0) return [];
+        return prisma.store.findMany({
+            where: { companyId: { in: companyIds }, isActive: true },
+            select: { id: true, name: true, code: true, companyId: true },
+        });
+    },
+
     // ======================
     // Elevation Operations
     // ======================

--- a/server/src/features/users/types.ts
+++ b/server/src/features/users/types.ts
@@ -52,6 +52,9 @@ export const storeRefSchema = z.discriminatedUnion('type', [
     }),
 ]);
 
+// Company roles that grant all-stores access
+const ALL_STORES_COMPANY_ROLES = ['SUPER_USER', 'COMPANY_ADMIN', 'STORE_ADMIN'] as const;
+
 // Create user with company/store
 export const createUserSchema = z.object({
     email: z.string().email('Invalid email address'),
@@ -60,12 +63,11 @@ export const createUserSchema = z.object({
     phone: z.string().max(50).optional().nullable(),
     password: z.string().min(8, 'Password must be at least 8 characters'),
     company: companyRefSchema,
-    isCompanyAdmin: z.boolean().default(false),
-    allStoresAccess: z.boolean().default(false),
+    companyRole: z.enum(['COMPANY_ADMIN', 'STORE_ADMIN', 'STORE_VIEWER', 'VIEWER']).default('VIEWER'),
     stores: z.array(storeRefSchema).optional(),
 }).refine(
-    (data) => data.allStoresAccess || (data.stores && data.stores.length > 0),
-    { message: 'Either allStoresAccess must be true or at least one store must be specified', path: ['stores'] }
+    (data) => ALL_STORES_COMPANY_ROLES.includes(data.companyRole as any) || (data.stores && data.stores.length > 0),
+    { message: 'Per-store roles require at least one store assignment', path: ['stores'] }
 );
 
 export const updateUserSchema = z.object({
@@ -97,13 +99,11 @@ export const elevateUserSchema = z.object({
 
 export const assignUserToCompanySchema = z.object({
     company: companyRefSchema,
-    allStoresAccess: z.boolean().default(false),
-    isCompanyAdmin: z.boolean().default(false),
+    companyRole: z.enum(['COMPANY_ADMIN', 'STORE_ADMIN', 'STORE_VIEWER', 'VIEWER']).default('VIEWER'),
 });
 
 export const updateUserCompanySchema = z.object({
-    allStoresAccess: z.boolean().optional(),
-    isCompanyAdmin: z.boolean().optional(),
+    companyRole: z.enum(['COMPANY_ADMIN', 'STORE_ADMIN', 'STORE_VIEWER', 'VIEWER']).optional(),
 });
 
 export const updateContextSchema = z.object({

--- a/src/features/auth/application/permissionHelpers.ts
+++ b/src/features/auth/application/permissionHelpers.ts
@@ -16,7 +16,10 @@ const STORE_ROLE_HIERARCHY: Record<Store['role'], number> = {
 };
 
 const COMPANY_ROLE_HIERARCHY: Record<Company['role'], number> = {
-    'COMPANY_ADMIN': 2,
+    'SUPER_USER': 4,
+    'COMPANY_ADMIN': 3,
+    'STORE_ADMIN': 2,
+    'STORE_VIEWER': 1,
     'VIEWER': 1,
 };
 
@@ -38,7 +41,7 @@ export function isCompanyAdmin(user: User | null, companyId: string): boolean {
     if (isPlatformAdmin(user)) return true;
     
     const company = user.companies.find(c => c.id === companyId);
-    return company?.role === 'COMPANY_ADMIN';
+    return company?.role === 'COMPANY_ADMIN' || company?.role === 'SUPER_USER';
 }
 
 /**
@@ -248,8 +251,8 @@ export function canManageUsers(user: User | null, targetCompanyId?: string): boo
         return isCompanyAdmin(user, targetCompanyId);
     }
     
-    // Can manage users in any company they admin
-    return user.companies.some(c => c.role === 'COMPANY_ADMIN');
+    // Can manage users in any company they admin (COMPANY_ADMIN or SUPER_USER)
+    return user.companies.some(c => c.role === 'COMPANY_ADMIN' || c.role === 'SUPER_USER');
 }
 
 /**
@@ -291,9 +294,12 @@ export function getHighestRole(user: User | null): string {
     if (!user) return 'Guest';
     if (isPlatformAdmin(user)) return 'Platform Admin';
     
-    const hasCompanyAdmin = user.companies.some(c => c.role === 'COMPANY_ADMIN');
+    const hasCompanyAdmin = user.companies.some(c => c.role === 'COMPANY_ADMIN' || c.role === 'SUPER_USER');
     if (hasCompanyAdmin) return 'Company Admin';
-    
+
+    const hasCompanyStoreAdmin = user.companies.some(c => c.role === 'STORE_ADMIN');
+    if (hasCompanyStoreAdmin) return 'Store Admin';
+
     const hasStoreAdmin = user.stores.some(s => s.role === 'STORE_ADMIN');
     if (hasStoreAdmin) return 'Store Admin';
     

--- a/src/features/settings/presentation/EnhancedUserDialog.tsx
+++ b/src/features/settings/presentation/EnhancedUserDialog.tsx
@@ -146,7 +146,7 @@ export function EnhancedUserDialog({ open, onClose, onSave, user, profileMode = 
                                         isCreatingCompany={state.isCreatingCompany}
                                         companyRole={state.companyRole}
                                         allStoresAccess={state.allStoresAccess}
-                                        onAllStoresAccessChange={state.setAllStoresAccess}
+
                                         assignments={state.storeAssignments}
                                         onAssignmentsChange={state.setStoreAssignments}
                                         isEdit={state.isEdit}
@@ -288,7 +288,6 @@ export function EnhancedUserDialog({ open, onClose, onSave, user, profileMode = 
                         isCreatingCompany={state.isCreatingCompany}
                         companyRole={state.companyRole}
                         allStoresAccess={state.allStoresAccess}
-                        onAllStoresAccessChange={state.setAllStoresAccess}
                         assignments={state.storeAssignments}
                         onAssignmentsChange={state.setStoreAssignments}
                         isEdit={state.isEdit}

--- a/src/features/settings/presentation/StoreAssignment.tsx
+++ b/src/features/settings/presentation/StoreAssignment.tsx
@@ -9,14 +9,13 @@ import {
     Box,
     Typography,
     FormControl,
-    FormControlLabel,
     InputLabel,
     Select,
     MenuItem,
     Checkbox,
     FormGroup,
     FormLabel,
-    Switch,
+    FormControlLabel,
     Alert,
     CircularProgress,
     Chip,
@@ -44,7 +43,7 @@ const STORE_ROLES = ['STORE_VIEWER', 'STORE_EMPLOYEE', 'STORE_MANAGER', 'STORE_A
 type StoreRole = typeof STORE_ROLES[number];
 
 // Company roles
-const COMPANY_ROLES = ['VIEWER', 'COMPANY_ADMIN'] as const;
+const COMPANY_ROLES = ['VIEWER', 'STORE_VIEWER', 'STORE_ADMIN', 'COMPANY_ADMIN'] as const;
 type CompanyRole = typeof COMPANY_ROLES[number];
 
 /** Store assignment data */
@@ -201,15 +200,6 @@ export function StoreAssignment({
         );
     };
 
-    // Handle all stores access toggle
-    const handleAllStoresToggle = (checked: boolean) => {
-        onAllStoresAccessChange(checked);
-        if (checked) {
-            // Clear individual assignments when granting all stores access
-            onAssignmentsChange([]);
-        }
-    };
-
     if (loading) {
         return (
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 2 }}>
@@ -245,28 +235,13 @@ export function StoreAssignment({
         );
     }
 
+    // Derive allStoresAccess from company role
+    const isAllStoresRole = companyRole === 'COMPANY_ADMIN' || companyRole === 'STORE_ADMIN';
+
     return (
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-            {/* All Stores Access Toggle */}
-            {companyRole === 'COMPANY_ADMIN' && (
-                <FormControlLabel
-                    control={
-                        <Switch
-                            checked={allStoresAccess}
-                            onChange={(e) => handleAllStoresToggle(e.target.checked)}
-                            disabled={disabled}
-                        />
-                    }
-                    label={
-                        <Typography variant="body2">
-                            {t('settings.users.allStoresAccess', 'Access to all stores in company')}
-                        </Typography>
-                    }
-                />
-            )}
-
             {/* Individual Store Assignments */}
-            {!allStoresAccess && (
+            {!isAllStoresRole && (
                 <>
                     {/* Add Store Selector */}
                     {availableStores.length > 0 && (
@@ -404,9 +379,9 @@ export function StoreAssignment({
             )}
 
             {/* All Stores Access Info */}
-            {allStoresAccess && (
+            {isAllStoresRole && (
                 <Alert severity="success">
-                    {t('settings.users.allStoresAccessInfo', 
+                    {t('settings.users.allStoresAccessInfo',
                         'User will have access to all current and future stores in this company.')}
                 </Alert>
             )}

--- a/src/features/settings/presentation/UsersSettingsTab.tsx
+++ b/src/features/settings/presentation/UsersSettingsTab.tsx
@@ -269,16 +269,19 @@ export function UsersSettingsTab() {
                                 </TableRow>
                             ) : (
                                 users.map((user) => {
-                                    // Compute display role: globalRole > COMPANY_ADMIN > storeRole > companyRole > fallback
+                                    // Compute display role: globalRole > COMPANY_ADMIN/SUPER_USER > STORE_ADMIN > storeRole > companyRole > fallback
                                     const firstStore = user.stores?.[0];
                                     const firstCompany = user.companies?.[0];
                                     const companyRole = firstCompany?.role;
+                                    const isAdminCompanyRole = companyRole === 'COMPANY_ADMIN' || companyRole === 'SUPER_USER';
+                                    const isAllStoresRole = isAdminCompanyRole || companyRole === 'STORE_ADMIN';
                                     const userRole = user.globalRole
-                                        || (companyRole === 'COMPANY_ADMIN' ? 'COMPANY_ADMIN' : null)
+                                        || (isAdminCompanyRole ? 'COMPANY_ADMIN' : null)
+                                        || (companyRole === 'STORE_ADMIN' ? 'STORE_ADMIN' : null)
                                         || firstStore?.role
-                                        || companyRole // company VIEWER (no stores)
+                                        || companyRole
                                         || 'STORE_VIEWER';
-                                    const isAdminLevel = user.globalRole === 'PLATFORM_ADMIN' || companyRole === 'COMPANY_ADMIN';
+                                    const isAdminLevel = user.globalRole === 'PLATFORM_ADMIN' || isAllStoresRole;
                                     const userFeatures = isAdminLevel
                                         ? ['dashboard', 'spaces', 'conference', 'people']
                                         : (firstStore?.features || ['dashboard']);

--- a/src/features/settings/presentation/userDialog/UserCompanySection.tsx
+++ b/src/features/settings/presentation/userDialog/UserCompanySection.tsx
@@ -72,10 +72,10 @@ export function UserCompanySection({
                                         {t(`roles.${role.toLowerCase()}`)}
                                     </Typography>
                                     <Typography variant="caption" color="text.secondary">
-                                        {role === 'COMPANY_ADMIN'
-                                            ? t('settings.users.companyAdminDesc')
-                                            : t('settings.users.viewerDesc')
-                                        }
+                                        {role === 'COMPANY_ADMIN' && t('settings.users.companyAdminDesc')}
+                                        {role === 'STORE_ADMIN' && t('settings.users.storeAdminDesc')}
+                                        {role === 'STORE_VIEWER' && t('settings.users.storeViewerDesc')}
+                                        {role === 'VIEWER' && t('settings.users.viewerDesc')}
                                     </Typography>
                                 </Box>
                             </MenuItem>

--- a/src/features/settings/presentation/userDialog/UserStoreSection.tsx
+++ b/src/features/settings/presentation/userDialog/UserStoreSection.tsx
@@ -12,7 +12,6 @@ interface Props {
     isCreatingCompany: boolean;
     companyRole: CompanyRole;
     allStoresAccess: boolean;
-    onAllStoresAccessChange: (value: boolean) => void;
     assignments: StoreAssignmentData[];
     onAssignmentsChange: (assignments: StoreAssignmentData[]) => void;
     isEdit: boolean;
@@ -22,7 +21,7 @@ interface Props {
 
 export function UserStoreSection({
     companyId, isCreatingCompany, companyRole,
-    allStoresAccess, onAllStoresAccessChange,
+    allStoresAccess,
     assignments, onAssignmentsChange,
     isEdit, isEditing, companyEnabledFeatures,
 }: Props) {
@@ -37,7 +36,7 @@ export function UserStoreSection({
                 companyId={isCreatingCompany ? '' : companyId}
                 companyRole={companyRole}
                 allStoresAccess={allStoresAccess}
-                onAllStoresAccessChange={onAllStoresAccessChange}
+                onAllStoresAccessChange={() => {}}
                 assignments={assignments}
                 onAssignmentsChange={onAssignmentsChange}
                 disabled={isEdit && !isEditing}

--- a/src/features/settings/presentation/userDialog/types.ts
+++ b/src/features/settings/presentation/userDialog/types.ts
@@ -3,7 +3,7 @@
  */
 import type { StoreAssignmentData } from '../StoreAssignment';
 
-export const COMPANY_ROLES = ['VIEWER', 'COMPANY_ADMIN'] as const;
+export const COMPANY_ROLES = ['VIEWER', 'STORE_VIEWER', 'STORE_ADMIN', 'COMPANY_ADMIN'] as const;
 export type CompanyRole = typeof COMPANY_ROLES[number];
 
 export interface UserData {
@@ -21,7 +21,6 @@ export interface UserData {
     companies?: Array<{
         company: { id: string; name: string; code: string };
         role: CompanyRole;
-        allStoresAccess: boolean;
     }>;
     stores?: Array<{
         store: { id: string; name: string; code: string; companyId: string };

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -527,6 +527,8 @@
             "storeAssignments": "Store Assignments",
             "companyRole": "Company Role",
             "companyAdminDesc": "Can manage stores and users in this company",
+            "storeAdminDesc": "Admin access to all stores without company management",
+            "storeViewerDesc": "View-only access to assigned stores",
             "viewerDesc": "View-only access to company data",
             "steps": {
                 "basicInfo": "Basic Info",
@@ -1181,7 +1183,8 @@
         "store_manager": "Store Manager",
         "store_employee": "Store Employee",
         "store_viewer": "Store Viewer",
-        "platform_admin": "Platform Admin"
+        "platform_admin": "Platform Admin",
+        "super_user": "Super User"
     },
     "validation": {
         "required": "{{field}} is required",

--- a/src/locales/he/common.json
+++ b/src/locales/he/common.json
@@ -538,6 +538,8 @@
             "storeAssignments": "שיוך לחנויות",
             "companyRole": "תפקיד בחברה",
             "companyAdminDesc": "יכול לנהל חנויות ומשתמשים בחברה זו",
+            "storeAdminDesc": "גישת מנהל לכל החנויות ללא ניהול חברה",
+            "storeViewerDesc": "גישת צפייה בלבד לחנויות שהוקצו",
             "viewerDesc": "גישת צפייה בלבד לנתוני החברה",
             "steps": {
                 "basicInfo": "פרטים",
@@ -1196,7 +1198,8 @@
         "store_manager": "מנהל משמרת",
         "store_employee": "עובד חנות",
         "store_viewer": "צופה חנות",
-        "platform_admin": "מנהל מערכת"
+        "platform_admin": "מנהל מערכת",
+        "super_user": "משתמש על"
     },
     "validation": {
         "required": "{{field}} הוא שדה חובה",

--- a/src/shared/infrastructure/services/authService.ts
+++ b/src/shared/infrastructure/services/authService.ts
@@ -41,7 +41,7 @@ export interface Company {
     id: string;
     name: string;
     code: string;
-    role: 'COMPANY_ADMIN' | 'VIEWER';
+    role: 'SUPER_USER' | 'COMPANY_ADMIN' | 'STORE_ADMIN' | 'STORE_VIEWER' | 'VIEWER';
     allStoresAccess: boolean;
     companyFeatures?: CompanyFeatures;
     spaceType?: SpaceType;

--- a/src/shared/infrastructure/services/userService.ts
+++ b/src/shared/infrastructure/services/userService.ts
@@ -4,7 +4,7 @@ import api from './apiClient';
 export interface UserStoreAssignment {
     id: string;
     name: string;
-    storeNumber: string;
+    code: string;
     role: 'STORE_ADMIN' | 'STORE_MANAGER' | 'STORE_EMPLOYEE' | 'STORE_VIEWER';
     features: string[];
 }
@@ -13,7 +13,7 @@ export interface UserCompanyAssignment {
     id: string;
     code: string;
     name: string;
-    role: 'COMPANY_ADMIN' | 'VIEWER';
+    role: 'SUPER_USER' | 'COMPANY_ADMIN' | 'STORE_ADMIN' | 'STORE_VIEWER' | 'VIEWER';
     allStoresAccess: boolean;
 }
 


### PR DESCRIPTION
## Summary
- Adds `STORE_ADMIN` and `STORE_VIEWER` to the `CompanyRole` enum, filling the gap between `COMPANY_ADMIN` and `VIEWER`
- `allStoresAccess` is now **derived from role** (no more separate UI toggle): `SUPER_USER | COMPANY_ADMIN | STORE_ADMIN` → all stores; `STORE_VIEWER | VIEWER` → per-store only
- Users list API now expands stores for `allStoresAccess` users (fixes empty `stores: []` for company admins)
- Adds cache invalidation after all role/store/company mutations
- Fixes `storeNumber` → `code` mismatch in client `UserStoreAssignment`
- `SUPER_USER` now recognized in all `isCompanyAdmin` checks

## New Role Hierarchy

| CompanyRole    | All Stores? | Manage Company | Manage Users | Store Features |
|----------------|:-----------:|:--------------:|:------------:|:--------------:|
| SUPER_USER     | yes         | yes            | yes          | All            |
| COMPANY_ADMIN  | yes         | yes            | yes          | All            |
| STORE_ADMIN    | yes         | no             | no           | All (admin)    |
| STORE_VIEWER   | no          | no             | no           | View only      |
| VIEWER         | no          | no             | no           | View only      |

## DB Migration

The migration at `server/prisma/migrations/20260219000000_add_store_roles_to_company/migration.sql` adds two new enum values:
```sql
ALTER TYPE "CompanyRole" ADD VALUE 'STORE_ADMIN';
ALTER TYPE "CompanyRole" ADD VALUE 'STORE_VIEWER';
```
This is **additive only** (no data changes, no column modifications). It runs automatically via `prisma migrate deploy` in the deploy workflow.

## Files Changed (20 files)

**Server:**
- `server/prisma/schema.prisma` — enum expansion
- `server/prisma/migrations/...` — new migration
- `server/src/features/users/types.ts` — `companyRole` replaces `isCompanyAdmin` + `allStoresAccess` in DTOs
- `server/src/features/users/service.ts` — derive allStoresAccess, expand stores in list(), cache invalidation
- `server/src/features/users/repository.ts` — `findStoresByCompanyIds()` batch query
- `server/src/features/users/controller.ts` — expose `role` field in responses
- `server/src/features/auth/service.ts` — `allStoresAccess` in JWT
- `server/src/shared/middleware/auth.ts` — `requirePermission` fallback for allStoresAccess

**Client:**
- `src/shared/infrastructure/services/authService.ts` — Company.role expanded
- `src/shared/infrastructure/services/userService.ts` — `storeNumber` → `code`, role types
- `src/features/settings/presentation/userDialog/*` — role dropdown with 4 options, removed allStoresAccess toggle
- `src/features/settings/presentation/StoreAssignment.tsx` — role-based store visibility
- `src/features/settings/presentation/UsersSettingsTab.tsx` — role display for new roles
- `src/features/auth/application/permissionHelpers.ts` — hierarchy + SUPER_USER support
- `src/locales/{en,he}/common.json` — translations for new roles/descriptions

## Test plan
- [ ] Merge to main → CI/CD deploys and runs migration automatically
- [ ] Verify new enum values exist: `SELECT unnest(enum_range(NULL::"CompanyRole"));`
- [ ] Create user with STORE_ADMIN role → should auto-get allStoresAccess, see all stores
- [ ] Create user with STORE_VIEWER role → should require per-store assignment
- [ ] Users table shows correct role chips for all roles
- [ ] Edit existing COMPANY_ADMIN → role loads correctly, no allStoresAccess toggle
- [ ] STORE_ADMIN can manage store content but NOT company settings/users

🤖 Generated with [Claude Code](https://claude.com/claude-code)