### PR TITLE
fix: map SUPER_USER to COMPANY_ADMIN in UI role state

### DIFF
--- a/src/features/settings/presentation/userDialog/useUserDialogState.ts
+++ b/src/features/settings/presentation/userDialog/useUserDialogState.ts
@@ -133,7 +133,7 @@ export function useUserDialogState({ open, onSave, user, profileMode }: Params) 
                     const firstCompanyAssignment = data.companies?.[0];
                     if (firstCompanyAssignment) {
                         setSelectedCompanyId(firstCompanyAssignment.company.id);
-                        setCompanyRole(firstCompanyAssignment.role);
+                        setCompanyRole(firstCompanyAssignment.role === 'SUPER_USER' ? 'COMPANY_ADMIN' : firstCompanyAssignment.role);
                     }
 
                     const userStoreAssignments: StoreAssignmentData[] = (data.stores || [])
@@ -195,7 +195,7 @@ export function useUserDialogState({ open, onSave, user, profileMode }: Params) 
                 const firstCompanyAssignment = userToUse.companies?.[0];
                 if (firstCompanyAssignment) {
                     setSelectedCompanyId(firstCompanyAssignment.company.id);
-                    setCompanyRole(firstCompanyAssignment.role);
+                    setCompanyRole(firstCompanyAssignment.role === 'SUPER_USER' ? 'COMPANY_ADMIN' : firstCompanyAssignment.role);
                 }
 
                 const userStoreAssignments: StoreAssignmentData[] = (userToUse.stores || [])
@@ -402,7 +402,6 @@ export function useUserDialogState({ open, onSave, user, profileMode }: Params) 
                 // Handle company assignment
                 const userWithCompanies = fetchedUserData || user;
                 const existingCompanyAssignment = userWithCompanies.companies?.find(c => c.company.id === companyId);
-                const hasAnyCompanyAssignment = userWithCompanies.companies && userWithCompanies.companies.length > 0;
 
                 if (companyId) {
                     if (existingCompanyAssignment) {


### PR DESCRIPTION
## Summary
- Maps `SUPER_USER` (server-only role) to `COMPANY_ADMIN` when loading user data into the dialog's companyRole state
- Fixes TypeScript build error where `ServerCompanyRole` (includes SUPER_USER) couldn't be assigned to `CompanyRole` state setter (which only allows UI-selectable roles)
- This was caught by the stricter `tsc -b` in the Docker CI build

## Test plan
- [ ] Open edit dialog for a SUPER_USER — role should display as Company Admin
- [ ] Open profile dialog for platform admin — no crash, role loads correctly
- [ ] Docker build passes (`tsc -b` clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)