### PR TITLE
fix: use filled variant for role chip in users table

### DIFF
--- a/src/features/settings/presentation/UsersSettingsTab.tsx
+++ b/src/features/settings/presentation/UsersSettingsTab.tsx
@@ -306,6 +306,7 @@ export function UsersSettingsTab() {
                                                 <Chip
                                                     label={t(`roles.${userRole.toLowerCase()}`)}
                                                     color={getRoleColor(userRole) as any}
+                                                    variant='filled'
                                                     size="small"
                                                     sx={{ p: 1 }}
                                                 />


### PR DESCRIPTION
## Summary
- Set `variant='filled'` on the role `Chip` in the users settings table for better visual distinction

## Test plan
- [ ] Role chips in the users table display with filled background

🤖 Generated with [Claude Code](https://claude.com/claude-code)