### PR TITLE
fix: scope conference rooms and spaces to active store

### DIFF
--- a/src/features/conference/infrastructure/conferenceApi.ts
+++ b/src/features/conference/infrastructure/conferenceApi.ts
@@ -62,8 +62,8 @@ export const conferenceApi = {
     /**
      * Get all conference rooms with stats
      */
-    getAll: async (): Promise<{ rooms: ConferenceRoom[]; stats: ConferenceStatsResponse['stats'] }> => {
-        const response = await api.get<ConferenceStatsResponse>('/conference');
+    getAll: async (params?: { storeId?: string }): Promise<{ rooms: ConferenceRoom[]; stats: ConferenceStatsResponse['stats'] }> => {
+        const response = await api.get<ConferenceStatsResponse>('/conference', { params });
         return {
             rooms: response.data.data.map(transformRoom),
             stats: response.data.stats,

--- a/src/features/conference/infrastructure/conferenceStore.ts
+++ b/src/features/conference/infrastructure/conferenceStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { persist, devtools } from 'zustand/middleware';
 import type { ConferenceRoom } from '@shared/domain/types';
 import { conferenceApi } from './conferenceApi';
+import { useAuthStore } from '@features/auth/infrastructure/authStore';
 
 interface ConferenceStore {
     // State
@@ -89,7 +90,8 @@ export const useConferenceStore = create<ConferenceStore>()(
                 fetchRooms: async () => {
                     set({ isLoading: true, error: null }, false, 'fetchRooms/start');
                     try {
-                        const { rooms } = await conferenceApi.getAll();
+                        const storeId = useAuthStore.getState().activeStoreId;
+                        const { rooms } = await conferenceApi.getAll(storeId ? { storeId } : undefined);
                         set({ conferenceRooms: rooms, isLoading: false }, false, 'fetchRooms/success');
                     } catch (error) {
                         const message = error instanceof Error ? error.message : 'Failed to fetch rooms';

--- a/src/features/space/infrastructure/spacesApi.ts
+++ b/src/features/space/infrastructure/spacesApi.ts
@@ -54,6 +54,7 @@ interface SpacesQueryParams {
     limit?: number;
     search?: string;
     hasLabel?: boolean;
+    storeId?: string;
 }
 
 // Spaces API service

--- a/src/features/space/infrastructure/spacesStore.ts
+++ b/src/features/space/infrastructure/spacesStore.ts
@@ -3,6 +3,7 @@ import { persist, devtools } from 'zustand/middleware';
 import type { Space } from '@shared/domain/types';
 import type { SpacesList } from '../domain/types';
 import { spacesApi } from './spacesApi';
+import { useAuthStore } from '@features/auth/infrastructure/authStore';
 
 export interface SpacesStore {
     // State
@@ -93,7 +94,8 @@ export const useSpacesStore = create<SpacesStore>()(
                 fetchSpaces: async () => {
                     set({ isLoading: true, error: null }, false, 'fetchSpaces/start');
                     try {
-                        const { spaces } = await spacesApi.getAll();
+                        const storeId = useAuthStore.getState().activeStoreId;
+                        const { spaces } = await spacesApi.getAll(storeId ? { storeId } : undefined);
                         set({ spaces, isLoading: false }, false, 'fetchSpaces/success');
                     } catch (error) {
                         const message = error instanceof Error ? error.message : 'Failed to fetch spaces';


### PR DESCRIPTION
## Summary
- Conference and spaces fetch APIs now pass `activeStoreId` to the server, so results are filtered to the current store only
- Previously, these APIs fetched data from **all** stores the user has access to, causing rooms/spaces from different stores to appear together
- People feature already passed `storeId` correctly — this brings conference and spaces in line

## Changed files
- `src/features/conference/infrastructure/conferenceApi.ts` — accept `storeId` param
- `src/features/conference/infrastructure/conferenceStore.ts` — pass `activeStoreId` on fetch
- `src/features/space/infrastructure/spacesApi.ts` — add `storeId` to query params type
- `src/features/space/infrastructure/spacesStore.ts` — pass `activeStoreId` on fetch

## Test plan
- [ ] Switch between stores in a multi-store company
- [ ] Verify conference rooms only show rooms belonging to the active store
- [ ] Verify spaces only show spaces belonging to the active store
- [ ] Verify creating a conference room in store A does not appear in store B

🤖 Generated with [Claude Code](https://claude.com/claude-code)