### PR TITLE
fix: stop persisting conference rooms across store switches

### DIFF
--- a/src/features/conference/infrastructure/conferenceStore.ts
+++ b/src/features/conference/infrastructure/conferenceStore.ts
@@ -177,10 +177,20 @@ export const useConferenceStore = create<ConferenceStore>()(
             }),
             {
                 name: 'conference-store',
-                partialize: (state) => ({
-                    conferenceRooms: state.conferenceRooms,
-                    // Don't persist loading/error states
+                version: 2,
+                partialize: () => ({
+                    // Do NOT persist conferenceRooms — always fresh-fetch from server.
+                    // Persisting causes stale rooms from a previous store to flash
+                    // when switching stores (especially for multi-store users).
                 }),
+                migrate: (persistedState: unknown, version: number) => {
+                    const state = persistedState as Record<string, unknown>;
+                    if (version < 2) {
+                        // Strip stale conference rooms from old localStorage data
+                        delete state.conferenceRooms;
+                    }
+                    return state as any;
+                },
             }
         ),
         { name: 'ConferenceStore' }


### PR DESCRIPTION
## Summary
- Conference rooms were persisted to localStorage via Zustand `persist` middleware
- When a multi-store user switched stores, stale rooms from the previous store appeared immediately (hydrated from localStorage) before the fresh fetch could replace them
- Now `conferenceRooms` are excluded from persistence — always fetched fresh from the server on each store switch
- This matches the pattern already used by the spaces store (which had the same bug and was previously fixed)
- Includes a migration (version bump to 2) that strips stale `conferenceRooms` from existing localStorage

## Test plan
- [ ] Log in as a company admin with access to multiple stores
- [ ] Navigate to conference rooms on Store A — verify only Store A rooms appear
- [ ] Switch to Store B — verify only Store B rooms appear (no Store A rooms flash)
- [ ] Refresh the page on Store B — verify only Store B rooms appear (no localStorage contamination)

🤖 Generated with [Claude Code](https://claude.com/claude-code)