### PR TITLE
fix: scope space assignment check to person's store

### DIFF
--- a/server/src/features/people/repository.ts
+++ b/server/src/features/people/repository.ts
@@ -156,15 +156,17 @@ export const peopleRepository = {
     },
 
     /**
-     * Check if space is assigned to another person
+     * Check if space is assigned to another person within the same store
      */
-    async isSpaceAssigned(spaceId: string, excludePersonId: string) {
-        return prisma.person.findFirst({
-            where: {
-                assignedSpaceId: spaceId,
-                id: { not: excludePersonId },
-            },
-        });
+    async isSpaceAssigned(spaceId: string, excludePersonId: string, storeId?: string) {
+        const where: any = {
+            assignedSpaceId: spaceId,
+            id: { not: excludePersonId },
+        };
+        if (storeId) {
+            where.storeId = storeId;
+        }
+        return prisma.person.findFirst({ where });
     },
 
     /**

--- a/server/src/features/people/service.ts
+++ b/server/src/features/people/service.ts
@@ -172,8 +172,8 @@ export const peopleService = {
             throw new Error('PERSON_NOT_FOUND');
         }
 
-        // Check if this slot is already assigned to a different person
-        const alreadyAssigned = await peopleRepository.isSpaceAssigned(spaceId, personId);
+        // Check if this slot is already assigned to a different person in the same store
+        const alreadyAssigned = await peopleRepository.isSpaceAssigned(spaceId, personId, person.storeId);
         if (alreadyAssigned) {
             throw new Error('SPACE_ALREADY_ASSIGNED');
         }


### PR DESCRIPTION
## Summary
- `isSpaceAssigned()` queried globally across all stores, causing false "Space is already assigned" 400 errors when the same space ID existed in different stores
- Now scoped to the person's `storeId` so assignments only conflict within the same store
- This fixes the assign space error for company admins with multi-store access

## Test plan
- [ ] As a company admin, assign a space to a person in Store A — should succeed
- [ ] Assign the same space ID to a person in Store B — should also succeed (different store)
- [ ] Try assigning an already-used space within the same store — should still correctly return 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)