### PR TITLE
fix: STORE_ADMIN per-store only + dashboard label counts

### DIFF
--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -163,8 +163,8 @@ model UserCompany {
 
 enum CompanyRole {
   SUPER_USER     // For PLATFORM_ADMIN - full access without restrictions
-  COMPANY_ADMIN  // Can manage company settings, users, stores
-  STORE_ADMIN    // All-stores admin without company management
+  COMPANY_ADMIN  // Can manage company settings, users, stores, all-stores access
+  STORE_ADMIN    // Per-store admin (needs explicit store assignments)
   STORE_VIEWER   // Per-store view-only access
   VIEWER         // Read-only access
 }

--- a/server/src/features/users/service.ts
+++ b/server/src/features/users/service.ts
@@ -33,7 +33,7 @@ import type {
 // Role Helpers
 // ======================
 
-const ALL_STORES_ROLES: CompanyRole[] = ['SUPER_USER', 'COMPANY_ADMIN', 'STORE_ADMIN'];
+const ALL_STORES_ROLES: CompanyRole[] = ['SUPER_USER', 'COMPANY_ADMIN'];
 
 /** Derive allStoresAccess from a CompanyRole */
 function derivesAllStoresAccess(role: CompanyRole): boolean {

--- a/src/features/dashboard/DashboardPage.tsx
+++ b/src/features/dashboard/DashboardPage.tsx
@@ -77,19 +77,17 @@ export function DashboardPage() {
 
     // Calculate assigned labels dynamically from actual data
     // Count total assigned labels from assignedLabels arrays (from AIMS article fetch)
-    const assignedLabelsCount = useMemo(() => {
-        // Count all labels from spaces
-        const spaceLabelsCount = spaceController.spaces.reduce(
-            (count, s) => count + (s.assignedLabels?.length || 0),
-            0
-        );
-        // Count all labels from conference rooms
-        const conferenceLabelsCount = conferenceController.conferenceRooms.reduce(
-            (count, r) => count + (r.assignedLabels?.length || 0),
-            0
-        );
-        return spaceLabelsCount + conferenceLabelsCount;
-    }, [spaceController.spaces, conferenceController.conferenceRooms]);
+    const spacesAssignedLabelsCount = useMemo(() =>
+        spaceController.spaces.reduce((count, s) => count + (s.assignedLabels?.length || 0), 0),
+        [spaceController.spaces]
+    );
+
+    const conferenceAssignedLabelsCount = useMemo(() =>
+        conferenceController.conferenceRooms.reduce((count, r) => count + (r.assignedLabels?.length || 0), 0),
+        [conferenceController.conferenceRooms]
+    );
+
+    const assignedLabelsCount = spacesAssignedLabelsCount + conferenceAssignedLabelsCount;
 
     // Dialogs State
     const [spaceDialogOpen, setSpaceDialogOpen] = useState(false);
@@ -146,6 +144,7 @@ export function DashboardPage() {
                             totalSpaces={totalSpaces}
                             spacesWithLabels={spacesWithLabels}
                             spacesWithoutLabels={spacesWithoutLabels}
+                            assignedLabelsCount={spacesAssignedLabelsCount}
                             onAddSpace={() => setSpaceDialogOpen(true)}
                             hideAddButton={isMobile}
                         />
@@ -172,6 +171,7 @@ export function DashboardPage() {
                         totalRooms={totalRooms}
                         roomsWithLabels={roomsWithLabels}
                         roomsWithoutLabels={roomsWithoutLabels}
+                        assignedLabelsCount={conferenceAssignedLabelsCount}
                         availableRooms={availableRooms}
                         occupiedRooms={occupiedRooms}
                         onAddRoom={() => setConferenceDialogOpen(true)}

--- a/src/features/dashboard/components/DashboardConferenceCard.tsx
+++ b/src/features/dashboard/components/DashboardConferenceCard.tsx
@@ -9,6 +9,7 @@ interface DashboardConferenceCardProps {
     totalRooms: number;
     roomsWithLabels: number;
     roomsWithoutLabels: number;
+    assignedLabelsCount: number;
     availableRooms: number;
     occupiedRooms: number;
     onAddRoom: () => void;
@@ -22,6 +23,7 @@ export function DashboardConferenceCard({
     totalRooms,
     roomsWithLabels,
     roomsWithoutLabels,
+    assignedLabelsCount,
     availableRooms,
     occupiedRooms,
     onAddRoom,
@@ -79,6 +81,16 @@ export function DashboardConferenceCard({
                                 </Typography>
                                 <Typography variant="h5" fontWeight={500} color="warning.main">
                                     {roomsWithoutLabels}
+                                </Typography>
+                            </Box>
+                        </Grid>
+                        <Grid size={{ xs: 6 }}>
+                            <Box>
+                                <Typography variant="body2" color="text.secondary">
+                                    {t('dashboard.assignedLabels')}
+                                </Typography>
+                                <Typography variant="h5" fontWeight={500} color="info.main">
+                                    {assignedLabelsCount}
                                 </Typography>
                             </Box>
                         </Grid>

--- a/src/features/dashboard/components/DashboardSpacesCard.tsx
+++ b/src/features/dashboard/components/DashboardSpacesCard.tsx
@@ -15,6 +15,7 @@ interface DashboardSpacesCardProps {
     totalSpaces: number;
     spacesWithLabels: number;
     spacesWithoutLabels: number;
+    assignedLabelsCount: number;
     onAddSpace: () => void;
     hideAddButton?: boolean;
 }
@@ -28,6 +29,7 @@ export function DashboardSpacesCard({
     totalSpaces,
     spacesWithLabels,
     spacesWithoutLabels,
+    assignedLabelsCount,
     onAddSpace,
     hideAddButton,
 }: DashboardSpacesCardProps) {
@@ -100,6 +102,16 @@ export function DashboardSpacesCard({
                                 </Typography>
                                 <Typography variant="h5" fontWeight={500} color="warning.main">
                                     {spacesWithoutLabels}
+                                </Typography>
+                            </Box>
+                        </Grid>
+                        <Grid size={{ xs: 6 }}>
+                            <Box>
+                                <Typography variant="body2" color="text.secondary">
+                                    {t('dashboard.assignedLabels')}
+                                </Typography>
+                                <Typography variant="h5" fontWeight={500} color="info.main">
+                                    {assignedLabelsCount}
                                 </Typography>
                             </Box>
                         </Grid>

--- a/src/features/settings/presentation/StoreAssignment.tsx
+++ b/src/features/settings/presentation/StoreAssignment.tsx
@@ -230,7 +230,7 @@ export function StoreAssignment({
     }
 
     // Derive allStoresAccess from company role
-    const isAllStoresRole = companyRole === 'COMPANY_ADMIN' || companyRole === 'STORE_ADMIN';
+    const isAllStoresRole = companyRole === 'COMPANY_ADMIN';
 
     return (
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>

--- a/src/features/settings/presentation/UsersSettingsTab.tsx
+++ b/src/features/settings/presentation/UsersSettingsTab.tsx
@@ -274,10 +274,9 @@ export function UsersSettingsTab() {
                                     const firstCompany = user.companies?.[0];
                                     const companyRole = firstCompany?.role;
                                     const isAdminCompanyRole = companyRole === 'COMPANY_ADMIN' || companyRole === 'SUPER_USER';
-                                    const isAllStoresRole = isAdminCompanyRole || companyRole === 'STORE_ADMIN';
+                                    const isAllStoresRole = isAdminCompanyRole;
                                     const userRole = user.globalRole
                                         || (isAdminCompanyRole ? 'COMPANY_ADMIN' : null)
-                                        || (companyRole === 'STORE_ADMIN' ? 'STORE_ADMIN' : null)
                                         || firstStore?.role
                                         || companyRole
                                         || 'STORE_VIEWER';


### PR DESCRIPTION
## Summary
- **STORE_ADMIN no longer gets `allStoresAccess`**: Only `SUPER_USER` and `COMPANY_ADMIN` automatically get all-stores access. STORE_ADMIN now requires explicit store assignments, making it a true per-store role.
- **Dashboard per-feature label counts**: Spaces and Conference cards now display the number of assigned labels for each feature (not just items with/without labels).

## Test plan
- [ ] Create a user with STORE_ADMIN role — verify store assignment step appears and user only sees assigned stores
- [ ] Verify COMPANY_ADMIN still gets all-stores access automatically
- [ ] Check dashboard Spaces card shows "Assigned Labels: N" count
- [ ] Check dashboard Conference card shows "Assigned Labels: N" count
- [ ] Run `npx tsc -b` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)