### PR TITLE
debug: article info endpoint diagnostic logging

### DIFF
--- a/server/src/shared/infrastructure/jobs/AimsPullSyncJob.ts
+++ b/server/src/shared/infrastructure/jobs/AimsPullSyncJob.ts
@@ -351,6 +351,12 @@ export class AimsSyncReconciliationJob {
         try {
             const articleInfoList = await aimsGateway.pullArticleInfo(storeId);
 
+            const withLabels = articleInfoList.filter(a => Array.isArray(a.assignedLabel) && a.assignedLabel.length > 0);
+            console.log(
+                `[AimsReconcile] Article info: fetched ${articleInfoList.length} articles, ` +
+                `${withLabels.length} have assignedLabel(s)`
+            );
+
             // --- Sync assignedLabels to DB ---
             for (const info of articleInfoList) {
                 const artId = info.articleId;

--- a/server/src/shared/infrastructure/services/solumService.ts
+++ b/server/src/shared/infrastructure/services/solumService.ts
@@ -338,10 +338,29 @@ export class SolumService {
             if (!response.data || response.status === 204) return [];
 
             const data = response.data;
+
+            // Debug: log response shape on first page to diagnose parsing
+            if (page === 0) {
+                const topKeys = Object.keys(data);
+                const rmType = data.responseMessage == null ? 'null' : Array.isArray(data.responseMessage) ? 'array' : typeof data.responseMessage;
+                const sample = data.responseMessage && typeof data.responseMessage === 'object' && !Array.isArray(data.responseMessage)
+                    ? Object.keys(data.responseMessage).slice(0, 10)
+                    : null;
+                console.log(`[SoluM] fetchArticleInfo response shape: topKeys=${JSON.stringify(topKeys)}, responseMessage type=${rmType}${sample ? `, rmKeys=${JSON.stringify(sample)}` : ''}`);
+            }
+
             const payload = data.responseMessage ?? data;
 
             if (Array.isArray(payload)) return payload;
-            return payload.articleList || payload.content || payload.data || [];
+            const articles = payload.articleList || payload.content || payload.data || [];
+
+            // Debug: log first article sample to verify assignedLabel presence
+            if (page === 0 && articles.length > 0) {
+                const s = articles[0];
+                console.log(`[SoluM] fetchArticleInfo sample article: articleId=${s.articleId}, assignedLabel=${JSON.stringify(s.assignedLabel)}, keys=${Object.keys(s).join(',')}`);
+            }
+
+            return articles;
         });
     }
 


### PR DESCRIPTION
## Summary
- Dashboard still shows 0 assigned labels after PR #33
- Adds diagnostic logging to identify the issue: response shape, sample article keys, and assignedLabel counts
- Logs on each reconcile cycle so we can see exactly what AIMS returns

## What to look for in logs
- `[SoluM] fetchArticleInfo response shape` — actual response keys from AIMS
- `[SoluM] fetchArticleInfo sample article` — whether `assignedLabel` exists on articles
- `[AimsReconcile] Article info: fetched X articles, Y have assignedLabel(s)` — bottom line count

## Test plan
- [ ] Deploy, wait ~60s for reconcile, check server logs for the 3 log lines above

🤖 Generated with [Claude Code](https://claude.com/claude-code)