### PR TITLE
fix: people-mode label sync build error (TS2353)

### DIFF
--- a/server/src/shared/infrastructure/jobs/AimsPullSyncJob.ts
+++ b/server/src/shared/infrastructure/jobs/AimsPullSyncJob.ts
@@ -392,9 +392,11 @@ export class AimsSyncReconciliationJob {
                         data: { assignedLabels: labels },
                     });
                 } else if (isPeopleMode) {
-                    // People mode: article IDs are slot numbers → sync to Person records
-                    await prisma.person.updateMany({
-                        where: { storeId, assignedSpaceId: artId },
+                    // People mode: article IDs are slot numbers (= person.assignedSpaceId).
+                    // Person model has no assignedLabels column — store in the Space record
+                    // that matches this slot so labels are still tracked for the store.
+                    await prisma.space.updateMany({
+                        where: { storeId, externalId: artId },
                         data: { assignedLabels: labels },
                     });
                 } else {


### PR DESCRIPTION
## Summary
- Fixes build error from PR #37: `Person` model has no `assignedLabels` column (only `Space` and `ConferenceRoom` do)
- People-mode label sync now writes to the `Space` record matching the slot `externalId` instead of the non-existent `Person.assignedLabels` field

## Root cause
PR #37 added `prisma.person.updateMany({ data: { assignedLabels } })` but the Prisma schema's `Person` model doesn't have an `assignedLabels` field — only `Space` and `ConferenceRoom` do. This caused `TS2353` at build time.

## Test plan
- [ ] Verify Docker build passes (`tsc` compiles clean)
- [ ] Confirm label sync still works for people-mode stores

🤖 Generated with [Claude Code](https://claude.com/claude-code)