### PR TITLE
fix: Loki volume permissions and resilient deploy pipeline

### DIFF
--- a/.github/workflows/deploy-ubuntu.yml
+++ b/.github/workflows/deploy-ubuntu.yml
@@ -30,11 +30,12 @@ jobs:
             git remote set-url origin "https://x-access-token:${GH_PAT}@github.com/AvivElectis/electisSpace.git"
             git pull origin main
 
-            echo "=== Building containers ==="
+            echo "=== Building app containers ==="
             docker compose -f docker-compose.infra.yml -f docker-compose.app.yml build
 
-            echo "=== Restarting services ==="
-            docker compose -f docker-compose.infra.yml -f docker-compose.app.yml up -d --remove-orphans
+            echo "=== Starting core services (Redis + App) ==="
+            docker compose -f docker-compose.infra.yml up -d redis
+            docker compose -f docker-compose.infra.yml -f docker-compose.app.yml up -d server client
 
             echo "=== Running migrations ==="
             docker compose -f docker-compose.infra.yml -f docker-compose.app.yml exec -T server npx prisma migrate deploy
@@ -42,6 +43,9 @@ jobs:
             echo "=== Health check ==="
             sleep 10
             curl -f http://localhost:3071/health || echo "Health check failed"
+
+            echo "=== Starting observability stack (non-blocking) ==="
+            docker compose -f docker-compose.infra.yml up -d loki promtail grafana || echo "WARNING: Observability stack failed to start (non-critical)"
 
             echo "=== Deployment complete ==="
             docker compose -f docker-compose.infra.yml -f docker-compose.app.yml ps

--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -32,6 +32,7 @@ services:
   loki:
     image: grafana/loki:3.4.2
     container_name: electisspace-loki
+    user: "0"   # Named volumes are root-owned; Loki 3.x defaults to uid 10001
     command: -config.file=/etc/loki/loki-config.yml
     ports:
       - "127.0.0.1:3100:3100"
@@ -43,6 +44,7 @@ services:
       interval: 15s
       timeout: 5s
       retries: 5
+      start_period: 30s
     restart: unless-stopped
     networks:
       - global-network


### PR DESCRIPTION
## Summary
- **Loki volume permissions** — run as `user: "0"` since Docker named volumes are root-owned but Loki 3.x defaults to uid 10001
- **Health check start_period** — added `start_period: 30s` so Loki has time to initialize on first run before health checks begin
- **Resilient deploy** — core services (Redis, API, client) start first with migrations + health check; observability stack (Loki, Promtail, Grafana) starts separately as non-blocking so failures never kill deployments

## Root cause
PR #40 introduced the observability stack. On first deploy, Loki couldn't write to its data directory due to volume permission mismatch. The unhealthy Loki blocked Promtail/Grafana (`depends_on: service_healthy`), and `set -e` in the deploy script caused the entire pipeline to exit before migrations ran.

## Test plan
- [ ] Merge and verify deploy succeeds on GitHub Actions
- [ ] Verify Loki becomes healthy (`curl http://localhost:3100/ready`)
- [ ] Verify Grafana accessible at `:3200` with Loki datasource

🤖 Generated with [Claude Code](https://claude.com/claude-code)