### PR TITLE
fix: remove unused assignedLabelsCount variable (TS6133)

### DIFF
--- a/src/features/dashboard/DashboardPage.tsx
+++ b/src/features/dashboard/DashboardPage.tsx
@@ -99,8 +99,6 @@ export function DashboardPage() {
         [conferenceController.conferenceRooms]
     );
 
-    const assignedLabelsCount = spacesAssignedLabelsCount + conferenceAssignedLabelsCount;
-
     // Dialogs State
     const [spaceDialogOpen, setSpaceDialogOpen] = useState(false);
     const [conferenceDialogOpen, setConferenceDialogOpen] = useState(false);


### PR DESCRIPTION
## Summary
- Remove unused `assignedLabelsCount` variable in `DashboardPage.tsx` that caused a TypeScript build error (`TS6133`) after PR #55 changed the People card to use `spacesAssignedLabelsCount` directly.

## Test plan
- [ ] CI build passes (TypeScript compilation succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)