### PR TITLE
fix: add assignedLabels to Person model for correct dashboard count

### DIFF
--- a/server/prisma/migrations/20260222000000_add_person_assigned_labels/migration.sql
+++ b/server/prisma/migrations/20260222000000_add_person_assigned_labels/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable: Add assigned_labels array column to people
+ALTER TABLE "people" ADD COLUMN "assigned_labels" TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -300,20 +300,21 @@ model Person {
   assignedSpaceId String?    @map("assigned_space_id")
   
   // Dynamic data fields
-  data         Json       @default("{}")
-  
+  data            Json       @default("{}")
+  assignedLabels  String[]   @default([]) @map("assigned_labels")
+
   // Sync status
   syncStatus   SyncStatus @default(PENDING) @map("sync_status")
   lastSyncedAt DateTime?  @map("last_synced_at")
-  
+
   // Timestamps
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
-  
+
   // Relations
   store           Store                    @relation(fields: [storeId], references: [id], onDelete: Cascade)
   listMemberships PeopleListMembership[]
-  
+
   @@index([storeId])
   @@index([assignedSpaceId])
   @@index([externalId])

--- a/server/src/shared/infrastructure/jobs/AimsPullSyncJob.ts
+++ b/server/src/shared/infrastructure/jobs/AimsPullSyncJob.ts
@@ -407,11 +407,9 @@ export class AimsSyncReconciliationJob {
                         data: { assignedLabels: labels },
                     });
                 } else if (isPeopleMode) {
-                    // People mode: article IDs are slot numbers (= person.assignedSpaceId).
-                    // Person model has no assignedLabels column — store in the Space record
-                    // that matches this slot so labels are still tracked for the store.
-                    await prisma.space.updateMany({
-                        where: { storeId, externalId: artId },
+                    // People mode: article IDs are slot numbers (= person.assignedSpaceId)
+                    await prisma.person.updateMany({
+                        where: { storeId, assignedSpaceId: artId },
                         data: { assignedLabels: labels },
                     });
                 } else {

--- a/src/features/dashboard/DashboardPage.tsx
+++ b/src/features/dashboard/DashboardPage.tsx
@@ -94,6 +94,11 @@ export function DashboardPage() {
         [spaceController.spaces]
     );
 
+    const peopleAssignedLabelsCount = useMemo(() =>
+        peopleStore.people.reduce((count, p) => count + (p.assignedLabels?.length || 0), 0),
+        [peopleStore.people]
+    );
+
     const conferenceAssignedLabelsCount = useMemo(() =>
         conferenceController.conferenceRooms.reduce((count, r) => count + (r.assignedLabels?.length || 0), 0),
         [conferenceController.conferenceRooms]
@@ -170,7 +175,7 @@ export function DashboardPage() {
                             totalPeople={totalPeople}
                             assignedPeople={assignedPeople}
                             unassignedPeople={unassignedPeople}
-                            assignedLabelsCount={spacesAssignedLabelsCount}
+                            assignedLabelsCount={peopleAssignedLabelsCount}
                             savedLists={savedLists}
                             activeListName={peopleStore.activeListName}
                         />

--- a/src/features/people/infrastructure/peopleApi.ts
+++ b/src/features/people/infrastructure/peopleApi.ts
@@ -12,6 +12,7 @@ interface ServerPerson {
     virtualSpaceId: string;
     externalId: string | null;
     assignedSpaceId: string | null;
+    assignedLabels?: string[];
     data: Record<string, unknown>;
     syncStatus: 'PENDING' | 'SYNCED' | 'ERROR';
     syncError: string | null;
@@ -40,6 +41,8 @@ function transformPerson(serverPerson: ServerPerson): Person {
         virtualSpaceId: serverPerson.virtualSpaceId,
         data: stringData,
         assignedSpaceId: serverPerson.assignedSpaceId || undefined,
+        assignedLabels: Array.isArray(serverPerson.assignedLabels) && serverPerson.assignedLabels.length > 0
+            ? serverPerson.assignedLabels : undefined,
         aimsSyncStatus: serverPerson.syncStatus === 'PENDING' ? 'pending' :
             serverPerson.syncStatus === 'SYNCED' ? 'synced' : 'error',
         lastSyncedAt: serverPerson.updatedAt,


### PR DESCRIPTION
Closes #57

## Summary
- Added `assignedLabels` column to Person model (`String[] @default([])`) with migration
- Updated sync job to write assigned labels to `Person` records (by `assignedSpaceId`) in people mode, instead of writing to non-existent `Space` records
- Added `assignedLabels` to client `ServerPerson` interface and `transformPerson()`
- Dashboard people card now reads from `peopleAssignedLabelsCount` (people store) instead of `spacesAssignedLabelsCount`

## Test plan
- [ ] `npx prisma migrate dev` — column added, no data loss, existing people rows get empty `[]`
- [ ] Server restart → sync job runs → people get assigned labels populated
- [ ] Dashboard people card shows correct assigned labels count
- [ ] Conference card still shows correct count (unaffected)
- [ ] Spaces mode dashboard unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)