### PR TITLE
feat: mobile-responsive settings dialogs with card views and chip pad…

### DIFF
--- a/src/features/labels/presentation/LabelsPage.tsx
+++ b/src/features/labels/presentation/LabelsPage.tsx
@@ -398,7 +398,7 @@ export function LabelsPage() {
                                 letterSpacing: '0.08em',
                             }}
                         >
-                            {t('labels.table.articleId', 'Article')}
+                            {t('labels.table.articleId', 'Article ID')}
                         </Typography>
                         {isLinked ? (
                             <Stack gap={0.5} sx={{ mt: 0.5 }}>
@@ -442,6 +442,7 @@ export function LabelsPage() {
                                     color={getSignalColor(label.signal) as any}
                                     sx={{
                                         height: 28,
+                                        px: 1,
                                         fontSize: '0.75rem',
                                         '& .MuiChip-icon': { fontSize: 16 },
                                     }}
@@ -455,6 +456,7 @@ export function LabelsPage() {
                                     color={getBatteryColor(label.battery) as any}
                                     sx={{
                                         height: 28,
+                                        px: 1,
                                         fontSize: '0.75rem',
                                         '& .MuiChip-icon': { fontSize: 16 },
                                     }}
@@ -467,6 +469,7 @@ export function LabelsPage() {
                                     color={getStatusColor(label.status) as any}
                                     sx={{
                                         height: 28,
+                                        px: 1,
                                         fontSize: '0.75rem',
                                     }}
                                 />
@@ -550,19 +553,15 @@ export function LabelsPage() {
                     }}
                 >
                     <Stack direction="row" alignItems="center" justifyContent="space-between">
-                        <Button
+                        <IconButton
                             size="small"
-                            startIcon={
-                                <Badge badgeContent={(searchQuery ? 1 : 0) + (filterLinkedOnly ? 1 : 0)} color="primary">
-                                    <FilterListIcon />
-                                </Badge>
-                            }
                             onClick={() => setFiltersOpen(!filtersOpen)}
-                            color={(searchQuery || filterLinkedOnly) ? 'primary' : 'inherit'}
-                            sx={{ textTransform: 'none', fontWeight: 600, fontSize: '0.85rem' }}
+                            color={(searchQuery || filterLinkedOnly) ? 'primary' : 'default'}
                         >
-                            {t('common.filters', 'Filters')}
-                        </Button>
+                            <Badge badgeContent={(searchQuery ? 1 : 0) + (filterLinkedOnly ? 1 : 0)} color="primary">
+                                <FilterListIcon />
+                            </Badge>
+                        </IconButton>
                         <Chip
                             label={`${filteredLabels.length} ${t('labels.totalCountShort', 'labels')}`}
                             size="small"

--- a/src/features/settings/presentation/CompaniesTab.tsx
+++ b/src/features/settings/presentation/CompaniesTab.tsx
@@ -1,6 +1,6 @@
 /**
  * Companies Settings Tab
- * 
+ *
  * @description Tab for managing companies. Only visible to PLATFORM_ADMIN users.
  * Displays a list of companies with options to create, edit, and delete.
  * Includes company details, AIMS configuration status, and store counts.
@@ -24,7 +24,12 @@ import {
     Tooltip,
     TextField,
     InputAdornment,
-    Alert
+    Alert,
+    useMediaQuery,
+    useTheme,
+    Card,
+    CardContent,
+    Divider
 } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -52,6 +57,9 @@ export function CompaniesTab() {
     const { t } = useTranslation();
     const { isPlatformAdmin, isCompanyAdmin } = useAuthContext();
     const { confirm, ConfirmDialog } = useConfirmDialog();
+
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
     // State
     const [companies, setCompanies] = useState<Company[]>([]);
@@ -183,9 +191,9 @@ export function CompaniesTab() {
     return (
         <Box>
             {/* Header */}
-            <Stack 
-                direction={{ xs: 'column', sm: 'row' }} 
-                justifyContent="space-between" 
+            <Stack
+                direction={{ xs: 'column', sm: 'row' }}
+                justifyContent="space-between"
                 alignItems={{ xs: 'stretch', sm: 'center' }}
                 gap={2}
                 sx={{ mb: 2 }}
@@ -232,163 +240,269 @@ export function CompaniesTab() {
                 </Alert>
             )}
 
-            {/* Companies Table */}
-            <Paper sx={{ width: '100%', overflow: 'hidden' }}>
-                <TableContainer sx={{ maxHeight: { xs: 400, md: 500 } }}>
-                    <Table stickyHeader size="small">
-                        <TableHead>
-                            <TableRow>
-                                <TableCell sx={{ minWidth: 80 }}>{t('settings.companies.code')}</TableCell>
-                                <TableCell sx={{ minWidth: 120 }}>{t('settings.companies.name')}</TableCell>
-                                <TableCell sx={{ minWidth: 100, display: { xs: 'none', md: 'table-cell' } }}>{t('settings.companies.location')}</TableCell>
-                                <TableCell align="center" sx={{ minWidth: 80 }}>{t('settings.companies.stores')}</TableCell>
-                                <TableCell align="center" sx={{ minWidth: 60, display: { xs: 'none', sm: 'table-cell' } }}>{t('settings.companies.aimsStatus')}</TableCell>
-                                <TableCell align="center" sx={{ minWidth: 80 }}>{t('settings.companies.status')}</TableCell>
-                                <TableCell sx={{ minWidth: 100, display: { xs: 'none', lg: 'table-cell' } }}>{t('settings.companies.created')}</TableCell>
-                                <TableCell align="right" sx={{ minWidth: 100 }}>{t('common.actions')}</TableCell>
-                            </TableRow>
-                        </TableHead>
-                        <TableBody>
-                            {loading ? (
-                                <TableRow>
-                                    <TableCell colSpan={8} align="center" sx={{ py: 4 }}>
-                                        <CircularProgress size={32} />
-                                    </TableCell>
-                                </TableRow>
-                            ) : companies.length === 0 ? (
-                                <TableRow>
-                                    <TableCell colSpan={8} align="center" sx={{ py: 4 }}>
-                                        <Typography color="text.secondary">
-                                            {searchQuery
-                                                ? t('settings.companies.noSearchResults')
-                                                : t('settings.companies.noCompanies')}
-                                        </Typography>
-                                    </TableCell>
-                                </TableRow>
-                            ) : (
-                                companies.map((company) => (
-                                    <TableRow key={company.id} hover>
-                                        <TableCell>
-                                            <Chip 
-                                                label={company.code} 
-                                                size="small" 
-                                                variant="outlined"
-                                                sx={{ p: 1, fontFamily: 'monospace', fontWeight: 'bold' }}
-                                            />
-                                        </TableCell>
-                                        <TableCell>
-                                            <Typography variant="body2" fontWeight="medium" noWrap>
-                                                {company.name}
-                                            </Typography>
-                                        </TableCell>
-                                        <TableCell sx={{ display: { xs: 'none', md: 'table-cell' } }}>
-                                            <Typography variant="body2" color="text.secondary" noWrap>
-                                                {company.location || '—'}
-                                            </Typography>
-                                        </TableCell>
-                                        <TableCell align="center">
+            {/* Companies Table / Mobile Cards */}
+            {isMobile ? (
+                <>
+                    {/* Mobile Card View */}
+                    {loading ? (
+                        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+                            <CircularProgress size={32} />
+                        </Box>
+                    ) : companies.length === 0 ? (
+                        <Box sx={{ textAlign: 'center', py: 4 }}>
+                            <Typography color="text.secondary">
+                                {searchQuery
+                                    ? t('settings.companies.noSearchResults')
+                                    : t('settings.companies.noCompanies')}
+                            </Typography>
+                        </Box>
+                    ) : (
+                        companies.map((company) => (
+                            <Card key={company.id} sx={{ mb: 1.5, overflow: 'hidden' }}>
+                                <Box sx={{ height: 3, background: company.isActive ? `linear-gradient(90deg, ${theme.palette.success.main}, ${theme.palette.success.light})` : theme.palette.grey[300] }} />
+                                <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
+                                    {/* Header: Company Code + Name + Actions */}
+                                    <Stack direction="row" alignItems="flex-start" justifyContent="space-between" gap={1}>
+                                        <Box sx={{ flex: 1, minWidth: 0 }}>
+                                            <Chip label={company.code} size="small" variant="outlined" sx={{ px: 1.5, fontFamily: 'monospace', fontWeight: 'bold' }} />
+                                            <Typography variant="subtitle2" fontWeight={600} sx={{ mt: 0.5 }}>{company.name}</Typography>
+                                            {company.location && <Typography variant="caption" color="text.secondary">{company.location}</Typography>}
+                                        </Box>
+                                        <Stack direction="row" gap={0.5}>
                                             <Tooltip title={t('settings.companies.manageStores')}>
-                                                <Chip
-                                                    icon={<StoreIcon fontSize="small" />}
-                                                    label={company.storeCount ?? company._count?.stores ?? 0}
-                                                    size="small"
-                                                    onClick={() => handleManageStores(company)}
-                                                    sx={{ p: 1, cursor: 'pointer' }}
-                                                />
+                                                <IconButton size="small" onClick={() => handleManageStores(company)}>
+                                                    <StoreIcon fontSize="small" />
+                                                </IconButton>
                                             </Tooltip>
-                                        </TableCell>
-                                        <TableCell align="center" sx={{ display: { xs: 'none', sm: 'table-cell' } }}>
-                                            <Tooltip
-                                                title={company.aimsConfigured
-                                                    ? t('settings.companies.aimsConfigured')
-                                                    : t('settings.companies.aimsNotConfigured')}
-                                            >
-                                                {company.aimsConfigured ? (
-                                                    <CloudIcon color="success" fontSize="small" />
-                                                ) : (
-                                                    <CloudOffIcon color="disabled" fontSize="small" />
-                                                )}
+                                            <Tooltip title={t('common.edit')}>
+                                                <IconButton size="small" onClick={() => handleEdit(company)}>
+                                                    <EditIcon fontSize="small" />
+                                                </IconButton>
                                             </Tooltip>
-                                        </TableCell>
-                                        <TableCell align="center">
-                                            <Chip
-                                                label={company.isActive
-                                                    ? t('common.active')
-                                                    : t('common.inactive')}
-                                                size="small"
-                                                color={company.isActive ? 'success' : 'default'}
-                                                variant={company.isActive ? 'filled' : 'outlined'}
-                                                sx={{ p: 1 }}
-                                            />
-                                        </TableCell>
-                                        <TableCell sx={{ display: { xs: 'none', lg: 'table-cell' } }}>
-                                            <Typography variant="body2" color="text.secondary">
-                                                {formatDate(company.createdAt)}
-                                            </Typography>
-                                        </TableCell>
-                                        <TableCell align="right">
-                                            <Stack direction="row" gap={0.5} justifyContent="flex-end">
-                                                <Tooltip title={t('settings.companies.manageStores')}>
-                                                    <IconButton
-                                                        size="small"
-                                                        onClick={() => handleManageStores(company)}
-                                                    >
-                                                        <StoreIcon fontSize="small" />
+                                            {isPlatformAdmin && (
+                                                <Tooltip title={t('common.delete')}>
+                                                    <IconButton size="small" color="error" onClick={() => handleDelete(company)}>
+                                                        <DeleteIcon fontSize="small" />
                                                     </IconButton>
                                                 </Tooltip>
-                                                <Tooltip title={t('common.edit')}>
-                                                    <IconButton
-                                                        size="small"
-                                                        onClick={() => handleEdit(company)}
-                                                    >
-                                                        <EditIcon fontSize="small" />
-                                                    </IconButton>
-                                                </Tooltip>
-                                                {isPlatformAdmin && (
-                                                    <Tooltip title={t('common.delete')}>
-                                                        <IconButton
-                                                            size="small"
-                                                            color="error"
-                                                            onClick={() => handleDelete(company)}
-                                                        >
-                                                            <DeleteIcon fontSize="small" />
-                                                        </IconButton>
-                                                    </Tooltip>
-                                                )}
-                                            </Stack>
+                                            )}
+                                        </Stack>
+                                    </Stack>
+                                    <Divider sx={{ my: 1.5 }} />
+                                    {/* Details Row */}
+                                    <Stack direction="row" gap={1} flexWrap="wrap" alignItems="center">
+                                        <Chip
+                                            icon={<StoreIcon fontSize="small" />}
+                                            label={company.storeCount ?? company._count?.stores ?? 0}
+                                            size="small"
+                                            onClick={() => handleManageStores(company)}
+                                            sx={{ px: 1.5, cursor: 'pointer' }}
+                                        />
+                                        <Tooltip title={company.aimsConfigured ? t('settings.companies.aimsConfigured') : t('settings.companies.aimsNotConfigured')}>
+                                            {company.aimsConfigured ? (
+                                                <CloudIcon color="success" fontSize="small" />
+                                            ) : (
+                                                <CloudOffIcon color="disabled" fontSize="small" />
+                                            )}
+                                        </Tooltip>
+                                        <Chip
+                                            label={company.isActive ? t('common.active') : t('common.inactive')}
+                                            size="small"
+                                            color={company.isActive ? 'success' : 'default'}
+                                            variant={company.isActive ? 'filled' : 'outlined'}
+                                            sx={{ px: 1.5 }}
+                                        />
+                                    </Stack>
+                                </CardContent>
+                            </Card>
+                        ))
+                    )}
+
+                    {/* Mobile Pagination */}
+                    <Paper sx={{ borderRadius: 3 }}>
+                        <TablePagination
+                            component="div"
+                            count={total}
+                            page={page}
+                            onPageChange={(_, newPage) => setPage(newPage)}
+                            rowsPerPage={limit}
+                            onRowsPerPageChange={(e) => {
+                                setLimit(parseInt(e.target.value, 10));
+                                setPage(0);
+                            }}
+                            rowsPerPageOptions={[5, 10, 25, 50]}
+                            labelRowsPerPage=""
+                            sx={{
+                                '.MuiTablePagination-selectLabel, .MuiTablePagination-displayedRows': {
+                                    margin: 0,
+                                },
+                                '.MuiTablePagination-toolbar': {
+                                    flexWrap: 'wrap',
+                                    justifyContent: 'center',
+                                    gap: 1,
+                                },
+                            }}
+                        />
+                    </Paper>
+                </>
+            ) : (
+                <Paper sx={{ width: '100%', overflow: 'hidden' }}>
+                    <TableContainer sx={{ maxHeight: { xs: 400, md: 500 } }}>
+                        <Table stickyHeader size="small">
+                            <TableHead>
+                                <TableRow>
+                                    <TableCell sx={{ minWidth: 80 }}>{t('settings.companies.code')}</TableCell>
+                                    <TableCell sx={{ minWidth: 120 }}>{t('settings.companies.name')}</TableCell>
+                                    <TableCell sx={{ minWidth: 100, display: { xs: 'none', md: 'table-cell' } }}>{t('settings.companies.location')}</TableCell>
+                                    <TableCell align="center" sx={{ minWidth: 80 }}>{t('settings.companies.stores')}</TableCell>
+                                    <TableCell align="center" sx={{ minWidth: 60, display: { xs: 'none', sm: 'table-cell' } }}>{t('settings.companies.aimsStatus')}</TableCell>
+                                    <TableCell align="center" sx={{ minWidth: 80 }}>{t('settings.companies.status')}</TableCell>
+                                    <TableCell sx={{ minWidth: 100, display: { xs: 'none', lg: 'table-cell' } }}>{t('settings.companies.created')}</TableCell>
+                                    <TableCell align="right" sx={{ minWidth: 100 }}>{t('common.actions')}</TableCell>
+                                </TableRow>
+                            </TableHead>
+                            <TableBody>
+                                {loading ? (
+                                    <TableRow>
+                                        <TableCell colSpan={8} align="center" sx={{ py: 4 }}>
+                                            <CircularProgress size={32} />
                                         </TableCell>
                                     </TableRow>
-                                ))
-                            )}
-                        </TableBody>
-                    </Table>
-                </TableContainer>
+                                ) : companies.length === 0 ? (
+                                    <TableRow>
+                                        <TableCell colSpan={8} align="center" sx={{ py: 4 }}>
+                                            <Typography color="text.secondary">
+                                                {searchQuery
+                                                    ? t('settings.companies.noSearchResults')
+                                                    : t('settings.companies.noCompanies')}
+                                            </Typography>
+                                        </TableCell>
+                                    </TableRow>
+                                ) : (
+                                    companies.map((company) => (
+                                        <TableRow key={company.id} hover>
+                                            <TableCell>
+                                                <Chip
+                                                    label={company.code}
+                                                    size="small"
+                                                    variant="outlined"
+                                                    sx={{ p: 1, px: 1.5, fontFamily: 'monospace', fontWeight: 'bold' }}
+                                                />
+                                            </TableCell>
+                                            <TableCell>
+                                                <Typography variant="body2" fontWeight="medium" noWrap>
+                                                    {company.name}
+                                                </Typography>
+                                            </TableCell>
+                                            <TableCell sx={{ display: { xs: 'none', md: 'table-cell' } }}>
+                                                <Typography variant="body2" color="text.secondary" noWrap>
+                                                    {company.location || '—'}
+                                                </Typography>
+                                            </TableCell>
+                                            <TableCell align="center">
+                                                <Tooltip title={t('settings.companies.manageStores')}>
+                                                    <Chip
+                                                        icon={<StoreIcon fontSize="small" />}
+                                                        label={company.storeCount ?? company._count?.stores ?? 0}
+                                                        size="small"
+                                                        onClick={() => handleManageStores(company)}
+                                                        sx={{ p: 1, px: 1.5, cursor: 'pointer' }}
+                                                    />
+                                                </Tooltip>
+                                            </TableCell>
+                                            <TableCell align="center" sx={{ display: { xs: 'none', sm: 'table-cell' } }}>
+                                                <Tooltip
+                                                    title={company.aimsConfigured
+                                                        ? t('settings.companies.aimsConfigured')
+                                                        : t('settings.companies.aimsNotConfigured')}
+                                                >
+                                                    {company.aimsConfigured ? (
+                                                        <CloudIcon color="success" fontSize="small" />
+                                                    ) : (
+                                                        <CloudOffIcon color="disabled" fontSize="small" />
+                                                    )}
+                                                </Tooltip>
+                                            </TableCell>
+                                            <TableCell align="center">
+                                                <Chip
+                                                    label={company.isActive
+                                                        ? t('common.active')
+                                                        : t('common.inactive')}
+                                                    size="small"
+                                                    color={company.isActive ? 'success' : 'default'}
+                                                    variant={company.isActive ? 'filled' : 'outlined'}
+                                                    sx={{ p: 1, px: 1.5 }}
+                                                />
+                                            </TableCell>
+                                            <TableCell sx={{ display: { xs: 'none', lg: 'table-cell' } }}>
+                                                <Typography variant="body2" color="text.secondary">
+                                                    {formatDate(company.createdAt)}
+                                                </Typography>
+                                            </TableCell>
+                                            <TableCell align="right">
+                                                <Stack direction="row" gap={0.5} justifyContent="flex-end">
+                                                    <Tooltip title={t('settings.companies.manageStores')}>
+                                                        <IconButton
+                                                            size="small"
+                                                            onClick={() => handleManageStores(company)}
+                                                        >
+                                                            <StoreIcon fontSize="small" />
+                                                        </IconButton>
+                                                    </Tooltip>
+                                                    <Tooltip title={t('common.edit')}>
+                                                        <IconButton
+                                                            size="small"
+                                                            onClick={() => handleEdit(company)}
+                                                        >
+                                                            <EditIcon fontSize="small" />
+                                                        </IconButton>
+                                                    </Tooltip>
+                                                    {isPlatformAdmin && (
+                                                        <Tooltip title={t('common.delete')}>
+                                                            <IconButton
+                                                                size="small"
+                                                                color="error"
+                                                                onClick={() => handleDelete(company)}
+                                                            >
+                                                                <DeleteIcon fontSize="small" />
+                                                            </IconButton>
+                                                        </Tooltip>
+                                                    )}
+                                                </Stack>
+                                            </TableCell>
+                                        </TableRow>
+                                    ))
+                                )}
+                            </TableBody>
+                        </Table>
+                    </TableContainer>
 
-                {/* Pagination */}
-                <TablePagination
-                    component="div"
-                    count={total}
-                    page={page}
-                    onPageChange={(_, newPage) => setPage(newPage)}
-                    rowsPerPage={limit}
-                    onRowsPerPageChange={(e) => {
-                        setLimit(parseInt(e.target.value, 10));
-                        setPage(0);
-                    }}
-                    rowsPerPageOptions={[5, 10, 25, 50]}
-                    labelRowsPerPage={t('common.rowsPerPage')}
-                    sx={{
-                        '.MuiTablePagination-selectLabel, .MuiTablePagination-displayedRows': {
-                            margin: 0,
-                        },
-                        '.MuiTablePagination-toolbar': {
-                            flexWrap: 'wrap',
-                            justifyContent: 'center',
-                            gap: 1,
-                        },
-                    }}
-                />
-            </Paper>
+                    {/* Pagination */}
+                    <TablePagination
+                        component="div"
+                        count={total}
+                        page={page}
+                        onPageChange={(_, newPage) => setPage(newPage)}
+                        rowsPerPage={limit}
+                        onRowsPerPageChange={(e) => {
+                            setLimit(parseInt(e.target.value, 10));
+                            setPage(0);
+                        }}
+                        rowsPerPageOptions={[5, 10, 25, 50]}
+                        labelRowsPerPage={t('common.rowsPerPage')}
+                        sx={{
+                            '.MuiTablePagination-selectLabel, .MuiTablePagination-displayedRows': {
+                                margin: 0,
+                            },
+                            '.MuiTablePagination-toolbar': {
+                                flexWrap: 'wrap',
+                                justifyContent: 'center',
+                                gap: 1,
+                            },
+                        }}
+                    />
+                </Paper>
+            )}
 
             {/* Confirm Dialog */}
             <ConfirmDialog />

--- a/src/features/settings/presentation/CompanyDialog.tsx
+++ b/src/features/settings/presentation/CompanyDialog.tsx
@@ -11,7 +11,7 @@
  * - EditCompanyTabs: edit mode tab layout
  * - CreateCompanyWizard: create mode wizard steps
  */
-import { Dialog } from '@mui/material';
+import { Dialog, useMediaQuery, useTheme } from '@mui/material';
 import { useCompanyDialogState } from './companyDialog/useCompanyDialogState';
 import { EditCompanyTabs } from './companyDialog/EditCompanyTabs';
 import { CreateCompanyWizard } from './companyDialog/CreateCompanyWizard';
@@ -25,6 +25,8 @@ interface CompanyDialogProps {
 }
 
 export function CompanyDialog({ open, onClose, onSave, company }: CompanyDialogProps) {
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
     const state = useCompanyDialogState({ open, onSave, company });
 
     return (
@@ -33,7 +35,8 @@ export function CompanyDialog({ open, onClose, onSave, company }: CompanyDialogP
             onClose={state.submitting || state.connecting ? undefined : onClose}
             maxWidth="sm"
             fullWidth
-            PaperProps={{ sx: { maxHeight: '90vh' } }}
+            fullScreen={isMobile}
+            PaperProps={{ sx: { maxHeight: isMobile ? '100%' : '90vh', borderRadius: isMobile ? 0 : undefined } }}
         >
             {state.isEdit
                 ? <EditCompanyTabs state={state} onClose={onClose} />

--- a/src/features/settings/presentation/ElevateUserDialog.tsx
+++ b/src/features/settings/presentation/ElevateUserDialog.tsx
@@ -20,7 +20,9 @@ import {
     ListItemIcon,
     ListItemText,
     Checkbox,
-    FormControlLabel
+    FormControlLabel,
+    useMediaQuery,
+    useTheme,
 } from '@mui/material';
 import WarningIcon from '@mui/icons-material/Warning';
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
@@ -41,6 +43,8 @@ interface ElevateUserDialogProps {
 
 export function ElevateUserDialog({ open, onClose, onSuccess, user }: ElevateUserDialogProps) {
     const { t } = useTranslation();
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
     // State
     const [submitting, setSubmitting] = useState(false);
@@ -82,14 +86,15 @@ export function ElevateUserDialog({ open, onClose, onSuccess, user }: ElevateUse
         : user.email;
 
     return (
-        <Dialog 
-            open={open} 
+        <Dialog
+            open={open}
             onClose={submitting ? undefined : onClose}
             maxWidth="sm"
             fullWidth
+            fullScreen={isMobile}
             TransitionProps={{ onEnter: handleEnter }}
             PaperProps={{
-                sx: { maxHeight: '90vh' }
+                sx: { maxHeight: isMobile ? '100%' : '90vh', borderRadius: isMobile ? 0 : undefined }
             }}
         >
             <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>

--- a/src/features/settings/presentation/EnhancedUserDialog.tsx
+++ b/src/features/settings/presentation/EnhancedUserDialog.tsx
@@ -25,6 +25,7 @@ import {
     Step,
     StepLabel,
     useTheme,
+    useMediaQuery,
 } from '@mui/material';
 import PersonIcon from '@mui/icons-material/Person';
 import { useTranslation } from 'react-i18next';
@@ -48,6 +49,7 @@ interface EnhancedUserDialogProps {
 export function EnhancedUserDialog({ open, onClose, onSave, user, profileMode = false }: EnhancedUserDialogProps) {
     const { t } = useTranslation();
     const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
     const isRtl = theme.direction === 'rtl';
 
     const state = useUserDialogState({ open, onClose, onSave, user, profileMode });
@@ -60,7 +62,8 @@ export function EnhancedUserDialog({ open, onClose, onSave, user, profileMode = 
                 onClose={state.submitting ? undefined : onClose}
                 maxWidth="sm"
                 fullWidth
-                PaperProps={{ sx: { maxHeight: '90vh' } }}
+                fullScreen={isMobile}
+                PaperProps={{ sx: { maxHeight: isMobile ? '100%' : '90vh', borderRadius: isMobile ? 0 : undefined } }}
             >
                 <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
                     <PersonIcon />
@@ -205,7 +208,8 @@ export function EnhancedUserDialog({ open, onClose, onSave, user, profileMode = 
             onClose={state.submitting ? undefined : onClose}
             maxWidth="sm"
             fullWidth
-            PaperProps={{ sx: { maxHeight: '90vh' } }}
+            fullScreen={isMobile}
+            PaperProps={{ sx: { maxHeight: isMobile ? '100%' : '90vh', borderRadius: isMobile ? 0 : undefined } }}
         >
             <DialogTitle>
                 {t('settings.users.addUser')}

--- a/src/features/settings/presentation/SolumFieldMappingTable.tsx
+++ b/src/features/settings/presentation/SolumFieldMappingTable.tsx
@@ -10,6 +10,13 @@ import {
     Paper,
     Typography,
     Box,
+    useMediaQuery,
+    useTheme,
+    Card,
+    CardContent,
+    Stack,
+    Switch,
+    FormControlLabel,
 } from '@mui/material';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -35,6 +42,8 @@ export function SolumFieldMappingTable({
     excludeFields = [],
 }: SolumFieldMappingTableProps) {
     const { t } = useTranslation();
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
     // Filter out globally assigned fields
     const visibleFields = articleFormatFields.filter(field => !excludeFields.includes(field));
@@ -42,12 +51,12 @@ export function SolumFieldMappingTable({
     // Calculate selection state for "select all" checkbox
     const { allSelected, someSelected } = useMemo(() => {
         if (visibleFields.length === 0) return { allSelected: false, someSelected: false };
-        
+
         const visibleCount = visibleFields.filter(fieldKey => {
             const mapping = mappings[fieldKey];
             return mapping?.visible !== false; // Default is true if not set
         }).length;
-        
+
         return {
             allSelected: visibleCount === visibleFields.length,
             someSelected: visibleCount > 0 && visibleCount < visibleFields.length,
@@ -58,7 +67,7 @@ export function SolumFieldMappingTable({
         const newMappings = { ...mappings };
         // If any are selected (some or all), uncheck all. Otherwise, check all.
         const newVisibleState = !allSelected && !someSelected;
-        
+
         visibleFields.forEach(fieldKey => {
             if (!newMappings[fieldKey]) {
                 newMappings[fieldKey] = {
@@ -109,6 +118,63 @@ export function SolumFieldMappingTable({
                 <Typography variant="body2" color="text.secondary">
                     {t('settings.fetchArticleSchemaFirst')}
                 </Typography>
+            </Box>
+        );
+    }
+
+    if (isMobile) {
+        return (
+            <Box>
+                <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1, px: 0.5 }}>
+                    <Typography variant="subtitle2" fontWeight={600}>{t('settings.fieldMapping', 'Field Mapping')}</Typography>
+                    <FormControlLabel
+                        control={<Switch checked={allSelected || someSelected} onChange={handleToggleAll} disabled={disabled} size="small" />}
+                        label={<Typography variant="caption">{t('settings.visible', 'Visible')}</Typography>}
+                        labelPlacement="start"
+                    />
+                </Stack>
+                {visibleFields.map((fieldKey) => {
+                    const mapping = mappings[fieldKey] || {
+                        friendlyNameEn: fieldKey,
+                        friendlyNameHe: fieldKey,
+                        visible: true,
+                    };
+                    return (
+                        <Card key={fieldKey} variant="outlined" sx={{ mb: 1 }}>
+                            <CardContent sx={{ p: 1.5, '&:last-child': { pb: 1.5 } }}>
+                                <Stack direction="row" alignItems="center" justifyContent="space-between">
+                                    <Typography variant="body2" sx={{ fontFamily: 'monospace', fontWeight: 600 }}>{fieldKey}</Typography>
+                                    <Switch
+                                        checked={mapping.visible}
+                                        onChange={(e) => handleVisibilityChange(fieldKey, e.target.checked)}
+                                        disabled={disabled}
+                                        size="small"
+                                    />
+                                </Stack>
+                                <Stack gap={1} sx={{ mt: 1 }}>
+                                    <TextField
+                                        fullWidth
+                                        size="small"
+                                        label={t('settings.englishName')}
+                                        value={mapping.friendlyNameEn}
+                                        onChange={(e) => handleNameChange(fieldKey, 'en', e.target.value)}
+                                        disabled={disabled}
+                                        placeholder={fieldKey}
+                                    />
+                                    <TextField
+                                        fullWidth
+                                        size="small"
+                                        label={t('settings.hebrewName')}
+                                        value={mapping.friendlyNameHe}
+                                        onChange={(e) => handleNameChange(fieldKey, 'he', e.target.value)}
+                                        disabled={disabled}
+                                        placeholder={fieldKey}
+                                    />
+                                </Stack>
+                            </CardContent>
+                        </Card>
+                    );
+                })}
             </Box>
         );
     }

--- a/src/features/settings/presentation/StoreDialog.tsx
+++ b/src/features/settings/presentation/StoreDialog.tsx
@@ -28,6 +28,8 @@ import {
     CardContent,
     CardActions,
     IconButton,
+    useMediaQuery,
+    useTheme,
 } from '@mui/material';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ErrorIcon from '@mui/icons-material/Error';
@@ -79,6 +81,8 @@ interface StoreDialogProps {
 
 export function StoreDialog({ open, onClose, onSave, companyId, store }: StoreDialogProps) {
     const { t } = useTranslation();
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
     const isEdit = !!store;
 
     // State
@@ -302,13 +306,14 @@ export function StoreDialog({ open, onClose, onSave, companyId, store }: StoreDi
     };
 
     return (
-        <Dialog 
-            open={open} 
+        <Dialog
+            open={open}
             onClose={submitting ? undefined : onClose}
             maxWidth="sm"
             fullWidth
+            fullScreen={isMobile}
             PaperProps={{
-                sx: { maxHeight: '90vh' }
+                sx: { maxHeight: isMobile ? '100%' : '90vh', borderRadius: isMobile ? 0 : undefined }
             }}
         >
             <DialogTitle>

--- a/src/features/settings/presentation/StoresDialog.tsx
+++ b/src/features/settings/presentation/StoresDialog.tsx
@@ -1,6 +1,6 @@
 /**
  * Stores Dialog
- * 
+ *
  * @description Dialog for managing stores within a company.
  * Lists all stores with options to add, edit, and delete.
  * Displays store details including sync status and entity counts.
@@ -23,8 +23,14 @@ import {
     CircularProgress,
     Stack,
     Tooltip,
-    Alert
+    Alert,
+    useMediaQuery,
+    Card,
+    CardContent,
+    Box,
+    Divider
 } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import AddIcon from '@mui/icons-material/Add';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -53,6 +59,8 @@ interface StoresDialogProps {
 export function StoresDialog({ open, onClose, company }: StoresDialogProps) {
     const { t } = useTranslation();
     const { confirm, ConfirmDialog } = useConfirmDialog();
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
     // State
     const [stores, setStores] = useState<CompanyStore[]>([]);
@@ -100,9 +108,9 @@ export function StoresDialog({ open, onClose, company }: StoresDialogProps) {
     };
 
     const handleDelete = async (store: CompanyStore) => {
-        const entityCount = 
-            (store.spaceCount ?? store._count?.spaces ?? 0) + 
-            (store.peopleCount ?? store._count?.people ?? 0) + 
+        const entityCount =
+            (store.spaceCount ?? store._count?.spaces ?? 0) +
+            (store.peopleCount ?? store._count?.people ?? 0) +
             (store.conferenceRoomCount ?? store._count?.conferenceRooms ?? 0);
 
         const confirmMessage = entityCount > 0
@@ -153,19 +161,20 @@ export function StoresDialog({ open, onClose, company }: StoresDialogProps) {
     };
 
     return (
-        <Dialog 
-            open={open} 
+        <Dialog
+            open={open}
             onClose={onClose}
             maxWidth="md"
             fullWidth
+            fullScreen={isMobile}
             PaperProps={{
-                sx: { maxHeight: '90vh' }
+                sx: { maxHeight: '90vh', borderRadius: isMobile ? 0 : undefined }
             }}
         >
             <DialogTitle sx={{ pb: 1 }}>
-                <Stack 
-                    direction={{ xs: 'column', sm: 'row' }} 
-                    alignItems={{ xs: 'flex-start', sm: 'center' }} 
+                <Stack
+                    direction={{ xs: 'column', sm: 'row' }}
+                    alignItems={{ xs: 'flex-start', sm: 'center' }}
                     gap={1}
                     flexWrap="wrap"
                 >
@@ -188,9 +197,9 @@ export function StoresDialog({ open, onClose, company }: StoresDialogProps) {
                 )}
 
                 {/* Header with Add Button */}
-                <Stack 
+                <Stack
                     direction={{ xs: 'column', sm: 'row' }}
-                    justifyContent="space-between" 
+                    justifyContent="space-between"
                     alignItems={{ xs: 'stretch', sm: 'center' }}
                     gap={1}
                     sx={{ mb: 2 }}
@@ -209,134 +218,183 @@ export function StoresDialog({ open, onClose, company }: StoresDialogProps) {
                     </Button>
                 </Stack>
 
-                {/* Stores Table */}
-                <TableContainer sx={{ maxHeight: { xs: 300, sm: 400 } }}>
-                    <Table size="small" stickyHeader>
-                        <TableHead>
-                            <TableRow>
-                                <TableCell sx={{ minWidth: 80 }}>{t('settings.stores.code')}</TableCell>
-                                <TableCell sx={{ minWidth: 120 }}>{t('settings.stores.name')}</TableCell>
-                                <TableCell sx={{ minWidth: 100, display: { xs: 'none', sm: 'table-cell' } }}>{t('settings.stores.timezone')}</TableCell>
-                                <TableCell align="center" sx={{ minWidth: 60 }}>{t('settings.stores.syncStatus')}</TableCell>
-                                <TableCell align="center" sx={{ minWidth: 150, display: { xs: 'none', md: 'table-cell' } }}>{t('settings.stores.entities')}</TableCell>
-                                <TableCell sx={{ minWidth: 150, display: { xs: 'none', lg: 'table-cell' } }}>{t('settings.stores.lastSync')}</TableCell>
-                                <TableCell align="right" sx={{ minWidth: 100 }}>{t('common.actions')}</TableCell>
-                            </TableRow>
-                        </TableHead>
-                        <TableBody>
-                            {loading ? (
+                {/* Mobile Cards View */}
+                {isMobile ? (
+                    loading ? (
+                        <Stack alignItems="center" gap={2} sx={{ py: 4 }}>
+                            <CircularProgress size={32} />
+                        </Stack>
+                    ) : safeStores.length === 0 ? (
+                        <Box sx={{ textAlign: 'center', py: 4 }}>
+                            <Typography color="text.secondary">
+                                {t('settings.stores.noStores')}
+                            </Typography>
+                        </Box>
+                    ) : (
+                        safeStores.map((store) => (
+                            <Card key={store.id} sx={{ mb: 1.5, overflow: 'hidden' }}>
+                                <Box sx={{ height: 3, background: store.syncEnabled ? `linear-gradient(90deg, ${theme.palette.success.main}, ${theme.palette.success.light})` : theme.palette.grey[300] }} />
+                                <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
+                                    <Stack direction="row" alignItems="flex-start" justifyContent="space-between" gap={1}>
+                                        <Box sx={{ flex: 1, minWidth: 0 }}>
+                                            <Chip label={store.code} size="small" variant="outlined" sx={{ px: 1.5, fontFamily: 'monospace' }} />
+                                            <Typography variant="subtitle2" fontWeight={600} sx={{ mt: 0.5 }}>{store.name}</Typography>
+                                            <Typography variant="caption" color="text.secondary">{store.timezone}</Typography>
+                                        </Box>
+                                        <Stack direction="row" gap={0.5}>
+                                            <Tooltip title={t('common.edit')}><IconButton size="small" onClick={() => handleEdit(store)}><EditIcon fontSize="small" /></IconButton></Tooltip>
+                                            <Tooltip title={t('common.delete')}><IconButton size="small" color="error" onClick={() => handleDelete(store)}><DeleteIcon fontSize="small" /></IconButton></Tooltip>
+                                        </Stack>
+                                    </Stack>
+                                    <Divider sx={{ my: 1.5 }} />
+                                    <Stack direction="row" gap={1} flexWrap="wrap" alignItems="center">
+                                        <Tooltip title={store.syncEnabled ? t('settings.stores.syncEnabled') : t('settings.stores.syncDisabled')}>
+                                            {store.syncEnabled ? <SyncIcon color="success" fontSize="small" /> : <SyncDisabledIcon color="disabled" fontSize="small" />}
+                                        </Tooltip>
+                                        <Chip label={`🏷️ ${store.spaceCount ?? store._count?.spaces ?? 0}`} size="small" variant="outlined" sx={{ px: 1.5 }} />
+                                        <Chip label={`👥 ${store.peopleCount ?? store._count?.people ?? 0}`} size="small" variant="outlined" sx={{ px: 1.5 }} />
+                                        <Chip label={`🎤 ${store.conferenceRoomCount ?? store._count?.conferenceRooms ?? 0}`} size="small" variant="outlined" sx={{ px: 1.5 }} />
+                                    </Stack>
+                                    {store.lastAimsSyncAt && (
+                                        <Stack direction="row" alignItems="center" gap={0.5} sx={{ mt: 1 }}>
+                                            <AccessTimeIcon fontSize="small" color="action" />
+                                            <Typography variant="caption" color="text.secondary">{formatDate(store.lastAimsSyncAt)}</Typography>
+                                        </Stack>
+                                    )}
+                                </CardContent>
+                            </Card>
+                        ))
+                    )
+                ) : (
+                    /* Desktop Stores Table */
+                    <TableContainer sx={{ maxHeight: { xs: 300, sm: 400 } }}>
+                        <Table size="small" stickyHeader>
+                            <TableHead>
                                 <TableRow>
-                                    <TableCell colSpan={7} align="center" sx={{ py: 4 }}>
-                                        <CircularProgress size={32} />
-                                    </TableCell>
+                                    <TableCell sx={{ minWidth: 80 }}>{t('settings.stores.code')}</TableCell>
+                                    <TableCell sx={{ minWidth: 120 }}>{t('settings.stores.name')}</TableCell>
+                                    <TableCell sx={{ minWidth: 100, display: { xs: 'none', sm: 'table-cell' } }}>{t('settings.stores.timezone')}</TableCell>
+                                    <TableCell align="center" sx={{ minWidth: 60 }}>{t('settings.stores.syncStatus')}</TableCell>
+                                    <TableCell align="center" sx={{ minWidth: 150, display: { xs: 'none', md: 'table-cell' } }}>{t('settings.stores.entities')}</TableCell>
+                                    <TableCell sx={{ minWidth: 150, display: { xs: 'none', lg: 'table-cell' } }}>{t('settings.stores.lastSync')}</TableCell>
+                                    <TableCell align="right" sx={{ minWidth: 100 }}>{t('common.actions')}</TableCell>
                                 </TableRow>
-                            ) : safeStores.length === 0 ? (
-                                <TableRow>
-                                    <TableCell colSpan={7} align="center" sx={{ py: 4 }}>
-                                        <Typography color="text.secondary">
-                                            {t('settings.stores.noStores')}
-                                        </Typography>
-                                    </TableCell>
-                                </TableRow>
-                            ) : (
-                                safeStores.map((store) => (
-                                    <TableRow key={store.id} hover>
-                                        <TableCell>
-                                            <Chip 
-                                                label={store.code} 
-                                                size="small" 
-                                                variant="outlined"
-                                                sx={{ fontFamily: 'monospace' }}
-                                            />
-                                        </TableCell>
-                                        <TableCell>
-                                            <Typography variant="body2" fontWeight="medium" noWrap sx={{ maxWidth: { xs: 100, sm: 150 } }}>
-                                                {store.name}
-                                            </Typography>
-                                        </TableCell>
-                                        <TableCell sx={{ display: { xs: 'none', sm: 'table-cell' } }}>
-                                            <Typography variant="body2" color="text.secondary" noWrap>
-                                                {store.timezone}
-                                            </Typography>
-                                        </TableCell>
-                                        <TableCell align="center">
-                                            <Tooltip
-                                                title={store.syncEnabled
-                                                    ? t('settings.stores.syncEnabled')
-                                                    : t('settings.stores.syncDisabled')}
-                                            >
-                                                {store.syncEnabled ? (
-                                                    <SyncIcon color="success" fontSize="small" />
-                                                ) : (
-                                                    <SyncDisabledIcon color="disabled" fontSize="small" />
-                                                )}
-                                            </Tooltip>
-                                        </TableCell>
-                                        <TableCell align="center" sx={{ display: { xs: 'none', md: 'table-cell' } }}>
-                                            <Stack 
-                                                direction="row" 
-                                                gap={0.5} 
-                                                justifyContent="center"
-                                                flexWrap="wrap"
-                                            >
-                                                <Tooltip title={t('settings.stores.spaces')}>
-                                                    <Chip 
-                                                        label={`🏷️ ${store.spaceCount ?? store._count?.spaces ?? 0}`} 
-                                                        size="small" 
-                                                        variant="outlined"
-                                                    />
-                                                </Tooltip>
-                                                <Tooltip title={t('settings.stores.people')}>
-                                                    <Chip 
-                                                        label={`👥 ${store.peopleCount ?? store._count?.people ?? 0}`} 
-                                                        size="small" 
-                                                        variant="outlined"
-                                                    />
-                                                </Tooltip>
-                                                <Tooltip title={t('settings.stores.conferenceRooms')}>
-                                                    <Chip 
-                                                        label={`🎤 ${store.conferenceRoomCount ?? store._count?.conferenceRooms ?? 0}`} 
-                                                        size="small" 
-                                                        variant="outlined"
-                                                    />
-                                                </Tooltip>
-                                            </Stack>
-                                        </TableCell>
-                                        <TableCell sx={{ display: { xs: 'none', lg: 'table-cell' } }}>
-                                            <Stack direction="row" alignItems="center" gap={0.5}>
-                                                <AccessTimeIcon fontSize="small" color="action" />
-                                                <Typography variant="body2" color="text.secondary" noWrap>
-                                                    {formatDate(store.lastAimsSyncAt)}
-                                                </Typography>
-                                            </Stack>
-                                        </TableCell>
-                                        <TableCell align="right">
-                                            <Stack direction="row" gap={0.5} justifyContent="flex-end">
-                                                <Tooltip title={t('common.edit')}>
-                                                    <IconButton
-                                                        size="small"
-                                                        onClick={() => handleEdit(store)}
-                                                    >
-                                                        <EditIcon fontSize="small" />
-                                                    </IconButton>
-                                                </Tooltip>
-                                                <Tooltip title={t('common.delete')}>
-                                                    <IconButton
-                                                        size="small"
-                                                        color="error"
-                                                        onClick={() => handleDelete(store)}
-                                                    >
-                                                        <DeleteIcon fontSize="small" />
-                                                    </IconButton>
-                                                </Tooltip>
-                                            </Stack>
+                            </TableHead>
+                            <TableBody>
+                                {loading ? (
+                                    <TableRow>
+                                        <TableCell colSpan={7} align="center" sx={{ py: 4 }}>
+                                            <CircularProgress size={32} />
                                         </TableCell>
                                     </TableRow>
-                                ))
-                            )}
-                        </TableBody>
-                    </Table>
-                </TableContainer>
+                                ) : safeStores.length === 0 ? (
+                                    <TableRow>
+                                        <TableCell colSpan={7} align="center" sx={{ py: 4 }}>
+                                            <Typography color="text.secondary">
+                                                {t('settings.stores.noStores')}
+                                            </Typography>
+                                        </TableCell>
+                                    </TableRow>
+                                ) : (
+                                    safeStores.map((store) => (
+                                        <TableRow key={store.id} hover>
+                                            <TableCell>
+                                                <Chip
+                                                    label={store.code}
+                                                    size="small"
+                                                    variant="outlined"
+                                                    sx={{ fontFamily: 'monospace' }}
+                                                />
+                                            </TableCell>
+                                            <TableCell>
+                                                <Typography variant="body2" fontWeight="medium" noWrap sx={{ maxWidth: { xs: 100, sm: 150 } }}>
+                                                    {store.name}
+                                                </Typography>
+                                            </TableCell>
+                                            <TableCell sx={{ display: { xs: 'none', sm: 'table-cell' } }}>
+                                                <Typography variant="body2" color="text.secondary" noWrap>
+                                                    {store.timezone}
+                                                </Typography>
+                                            </TableCell>
+                                            <TableCell align="center">
+                                                <Tooltip
+                                                    title={store.syncEnabled
+                                                        ? t('settings.stores.syncEnabled')
+                                                        : t('settings.stores.syncDisabled')}
+                                                >
+                                                    {store.syncEnabled ? (
+                                                        <SyncIcon color="success" fontSize="small" />
+                                                    ) : (
+                                                        <SyncDisabledIcon color="disabled" fontSize="small" />
+                                                    )}
+                                                </Tooltip>
+                                            </TableCell>
+                                            <TableCell align="center" sx={{ display: { xs: 'none', md: 'table-cell' } }}>
+                                                <Stack
+                                                    direction="row"
+                                                    gap={0.5}
+                                                    justifyContent="center"
+                                                    flexWrap="wrap"
+                                                >
+                                                    <Tooltip title={t('settings.stores.spaces')}>
+                                                        <Chip
+                                                            label={`🏷️ ${store.spaceCount ?? store._count?.spaces ?? 0}`}
+                                                            size="small"
+                                                            variant="outlined"
+                                                        />
+                                                    </Tooltip>
+                                                    <Tooltip title={t('settings.stores.people')}>
+                                                        <Chip
+                                                            label={`👥 ${store.peopleCount ?? store._count?.people ?? 0}`}
+                                                            size="small"
+                                                            variant="outlined"
+                                                        />
+                                                    </Tooltip>
+                                                    <Tooltip title={t('settings.stores.conferenceRooms')}>
+                                                        <Chip
+                                                            label={`🎤 ${store.conferenceRoomCount ?? store._count?.conferenceRooms ?? 0}`}
+                                                            size="small"
+                                                            variant="outlined"
+                                                        />
+                                                    </Tooltip>
+                                                </Stack>
+                                            </TableCell>
+                                            <TableCell sx={{ display: { xs: 'none', lg: 'table-cell' } }}>
+                                                <Stack direction="row" alignItems="center" gap={0.5}>
+                                                    <AccessTimeIcon fontSize="small" color="action" />
+                                                    <Typography variant="body2" color="text.secondary" noWrap>
+                                                        {formatDate(store.lastAimsSyncAt)}
+                                                    </Typography>
+                                                </Stack>
+                                            </TableCell>
+                                            <TableCell align="right">
+                                                <Stack direction="row" gap={0.5} justifyContent="flex-end">
+                                                    <Tooltip title={t('common.edit')}>
+                                                        <IconButton
+                                                            size="small"
+                                                            onClick={() => handleEdit(store)}
+                                                        >
+                                                            <EditIcon fontSize="small" />
+                                                        </IconButton>
+                                                    </Tooltip>
+                                                    <Tooltip title={t('common.delete')}>
+                                                        <IconButton
+                                                            size="small"
+                                                            color="error"
+                                                            onClick={() => handleDelete(store)}
+                                                        >
+                                                            <DeleteIcon fontSize="small" />
+                                                        </IconButton>
+                                                    </Tooltip>
+                                                </Stack>
+                                            </TableCell>
+                                        </TableRow>
+                                    ))
+                                )}
+                            </TableBody>
+                        </Table>
+                    </TableContainer>
+                )}
             </DialogContent>
 
             <DialogActions sx={{ px: 3, py: 2 }}>

--- a/src/features/settings/presentation/UsersSettingsTab.tsx
+++ b/src/features/settings/presentation/UsersSettingsTab.tsx
@@ -20,7 +20,12 @@ import {
     FormControl,
     InputLabel,
     Select,
-    MenuItem
+    MenuItem,
+    useMediaQuery,
+    useTheme,
+    Card,
+    CardContent,
+    Divider
 } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -45,6 +50,8 @@ export function UsersSettingsTab() {
     const { user: currentUser } = useAuthStore();
     const { isPlatformAdmin } = useAuthContext();
     const { confirm, ConfirmDialog } = useConfirmDialog();
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
     // State
     const [users, setUsers] = useState<User[]>([]);
@@ -239,161 +246,262 @@ export function UsersSettingsTab() {
                 </Stack>
             </Stack>
 
-            <Paper sx={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-                <TableContainer sx={{ flex: 1 }}>
-                    <Table stickyHeader size="small">
-                        <TableHead>
-                            <TableRow>
-                                <TableCell sx={{ minWidth: 150 }}>{t('auth.email')}</TableCell>
-                                <TableCell sx={{ minWidth: 100, display: { xs: 'none', sm: 'table-cell' } }}>{t('auth.name')}</TableCell>
-                                <TableCell sx={{ minWidth: 100 }}>{t('auth.role')}</TableCell>
-                                <TableCell sx={{ minWidth: 80, display: { xs: 'none', md: 'table-cell' } }}>{t('settings.users.features')}</TableCell>
-                                <TableCell sx={{ minWidth: 80 }}>{t('common.status.title')}</TableCell>
-                                <TableCell align="right" sx={{ minWidth: 100 }}>{t('common.actions')}</TableCell>
-                            </TableRow>
-                        </TableHead>
-                        <TableBody>
-                            {loading ? (
+            {isMobile ? (
+                <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+                    <Box sx={{ flex: 1, overflow: 'auto' }}>
+                        {loading ? (
+                            <Box sx={{ display: 'flex', justifyContent: 'center', py: 3 }}>
+                                <CircularProgress size={24} />
+                            </Box>
+                        ) : users.length === 0 ? (
+                            <Typography variant="body2" color="text.secondary" align="center" sx={{ py: 3 }}>
+                                {searchQuery
+                                    ? t('settings.users.noSearchResults')
+                                    : t('common.noData')}
+                            </Typography>
+                        ) : (
+                            users.map((user) => {
+                                const firstStore = user.stores?.[0];
+                                const firstCompany = user.companies?.[0];
+                                const companyRole = firstCompany?.role;
+                                const isAdminCompanyRole = companyRole === 'COMPANY_ADMIN' || companyRole === 'SUPER_USER';
+                                const isAllStoresRole = isAdminCompanyRole;
+                                const userRole = user.globalRole
+                                    || (isAdminCompanyRole ? 'COMPANY_ADMIN' : null)
+                                    || firstStore?.role
+                                    || companyRole
+                                    || 'STORE_VIEWER';
+                                const isAdminLevel = user.globalRole === 'PLATFORM_ADMIN' || isAllStoresRole;
+                                const userFeatures = isAdminLevel
+                                    ? ['dashboard', 'spaces', 'conference', 'people']
+                                    : (firstStore?.features || ['dashboard']);
+                                const canElevate = isPlatformAdmin &&
+                                    user.globalRole !== 'PLATFORM_ADMIN' &&
+                                    user.id !== currentUser?.id;
+
+                                return (
+                                    <Card key={user.id} sx={{ mb: 1.5, overflow: 'hidden' }}>
+                                        <Box sx={{ height: 3, background: user.isActive ? `linear-gradient(90deg, ${theme.palette.primary.main}, ${theme.palette.primary.light})` : theme.palette.grey[300] }} />
+                                        <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
+                                            <Stack direction="row" alignItems="flex-start" justifyContent="space-between" gap={1}>
+                                                <Box sx={{ flex: 1, minWidth: 0 }}>
+                                                    <Typography variant="body2" fontWeight={600} sx={{ wordBreak: 'break-all' }}>{user.email}</Typography>
+                                                    {(user.firstName || user.lastName) && (
+                                                        <Typography variant="caption" color="text.secondary">
+                                                            {`${user.firstName || ''} ${user.lastName || ''}`.trim()}
+                                                        </Typography>
+                                                    )}
+                                                </Box>
+                                                <Stack direction="row" gap={0.5}>
+                                                    {canElevate && (
+                                                        <Tooltip title={t('settings.users.elevate')}><IconButton onClick={() => handleElevate(user)} size="small" color="warning"><AdminPanelSettingsIcon fontSize="small" /></IconButton></Tooltip>
+                                                    )}
+                                                    <Tooltip title={t('common.edit')}><IconButton onClick={() => handleEdit(user)} size="small" color="primary"><EditIcon fontSize="small" /></IconButton></Tooltip>
+                                                    <Tooltip title={t('common.delete')}><span><IconButton onClick={() => handleDelete(user)} size="small" color="error" disabled={user.id === currentUser?.id}><DeleteIcon fontSize="small" /></IconButton></span></Tooltip>
+                                                </Stack>
+                                            </Stack>
+                                            <Divider sx={{ my: 1.5 }} />
+                                            <Stack direction="row" gap={0.75} flexWrap="wrap" alignItems="center">
+                                                <Chip label={t(`roles.${userRole.toLowerCase()}`)} color={getRoleColor(userRole) as any} variant="filled" size="small" sx={{ p: 1, px: 1.5 }} />
+                                                <Chip label={user.isActive ? t('common.status.active') : t('common.status.inactive')} color={user.isActive ? 'success' : 'default'} variant="outlined" size="small" sx={{ p: 1, px: 1.5 }} />
+                                            </Stack>
+                                            <Stack direction="row" gap={0.5} flexWrap="wrap" sx={{ mt: 1 }}>
+                                                {userFeatures.map(feature => (
+                                                    <Tooltip key={feature} title={t(`navigation.${feature}`)}>
+                                                        <span style={{ fontSize: '1.1rem' }}>{getFeatureIcon(feature)}</span>
+                                                    </Tooltip>
+                                                ))}
+                                            </Stack>
+                                        </CardContent>
+                                    </Card>
+                                );
+                            })
+                        )}
+                    </Box>
+                    <TablePagination
+                        component="div"
+                        count={total}
+                        page={page}
+                        onPageChange={(_, newPage) => setPage(newPage)}
+                        rowsPerPage={limit}
+                        onRowsPerPageChange={(e) => {
+                            setLimit(parseInt(e.target.value, 10));
+                            setPage(0);
+                        }}
+                        rowsPerPageOptions={[5, 10, 25, 50]}
+                        labelRowsPerPage={t('common.rowsPerPage')}
+                        sx={{
+                            '.MuiTablePagination-selectLabel': {
+                                display: 'none',
+                            },
+                            '.MuiTablePagination-displayedRows': {
+                                margin: 0,
+                            },
+                            '.MuiTablePagination-toolbar': {
+                                flexWrap: 'wrap',
+                                justifyContent: 'center',
+                                gap: 1,
+                            },
+                        }}
+                    />
+                </Box>
+            ) : (
+                <Paper sx={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+                    <TableContainer sx={{ flex: 1 }}>
+                        <Table stickyHeader size="small">
+                            <TableHead>
                                 <TableRow>
-                                    <TableCell colSpan={6} align="center" sx={{ py: 3 }}>
-                                        <CircularProgress size={24} />
-                                    </TableCell>
+                                    <TableCell sx={{ minWidth: 150 }}>{t('auth.email')}</TableCell>
+                                    <TableCell sx={{ minWidth: 100, display: { xs: 'none', sm: 'table-cell' } }}>{t('auth.name')}</TableCell>
+                                    <TableCell sx={{ minWidth: 100 }}>{t('auth.role')}</TableCell>
+                                    <TableCell sx={{ minWidth: 80, display: { xs: 'none', md: 'table-cell' } }}>{t('settings.users.features')}</TableCell>
+                                    <TableCell sx={{ minWidth: 80 }}>{t('common.status.title')}</TableCell>
+                                    <TableCell align="right" sx={{ minWidth: 100 }}>{t('common.actions')}</TableCell>
                                 </TableRow>
-                            ) : users.length === 0 ? (
-                                <TableRow>
-                                    <TableCell colSpan={6} align="center" sx={{ py: 3, color: 'text.secondary' }}>
-                                        {searchQuery 
-                                            ? t('settings.users.noSearchResults')
-                                            : t('common.noData')}
-                                    </TableCell>
-                                </TableRow>
-                            ) : (
-                                users.map((user) => {
-                                    // Compute display role: globalRole > COMPANY_ADMIN/SUPER_USER > STORE_ADMIN > storeRole > companyRole > fallback
-                                    const firstStore = user.stores?.[0];
-                                    const firstCompany = user.companies?.[0];
-                                    const companyRole = firstCompany?.role;
-                                    const isAdminCompanyRole = companyRole === 'COMPANY_ADMIN' || companyRole === 'SUPER_USER';
-                                    const isAllStoresRole = isAdminCompanyRole;
-                                    const userRole = user.globalRole
-                                        || (isAdminCompanyRole ? 'COMPANY_ADMIN' : null)
-                                        || firstStore?.role
-                                        || companyRole
-                                        || 'STORE_VIEWER';
-                                    const isAdminLevel = user.globalRole === 'PLATFORM_ADMIN' || isAllStoresRole;
-                                    const userFeatures = isAdminLevel
-                                        ? ['dashboard', 'spaces', 'conference', 'people']
-                                        : (firstStore?.features || ['dashboard']);
-                                    const canElevate = isPlatformAdmin && 
-                                        user.globalRole !== 'PLATFORM_ADMIN' && 
-                                        user.id !== currentUser?.id;
-                                    
-                                    return (
-                                        <TableRow key={user.id} hover>
-                                            <TableCell>
-                                                <Typography variant="body2" noWrap sx={{ maxWidth: { xs: 120, sm: 180 } }}>
-                                                    {user.email}
-                                                </Typography>
-                                            </TableCell>
-                                            <TableCell sx={{ display: { xs: 'none', sm: 'table-cell' } }}>
-                                                {user.firstName || user.lastName 
-                                                    ? <Typography variant="body2" noWrap>{`${user.firstName || ''} ${user.lastName || ''}`.trim()}</Typography>
-                                                    : <Typography variant="body2" color="text.secondary">—</Typography>
-                                                }
-                                            </TableCell>
-                                            <TableCell>
-                                                <Chip
-                                                    label={t(`roles.${userRole.toLowerCase()}`)}
-                                                    color={getRoleColor(userRole) as any}
-                                                    variant='filled'
-                                                    size="small"
-                                                    sx={{ p: 1 }}
-                                                />
-                                            </TableCell>
-                                            <TableCell sx={{ display: { xs: 'none', md: 'table-cell' } }}>
-                                                <Stack direction="row" gap={0.5} flexWrap="wrap">
-                                                    {userFeatures.map(feature => (
-                                                        <Tooltip key={feature} title={t(`navigation.${feature}`)}>
-                                                            <span style={{ fontSize: '1.1rem' }}>
-                                                                {getFeatureIcon(feature)}
+                            </TableHead>
+                            <TableBody>
+                                {loading ? (
+                                    <TableRow>
+                                        <TableCell colSpan={6} align="center" sx={{ py: 3 }}>
+                                            <CircularProgress size={24} />
+                                        </TableCell>
+                                    </TableRow>
+                                ) : users.length === 0 ? (
+                                    <TableRow>
+                                        <TableCell colSpan={6} align="center" sx={{ py: 3, color: 'text.secondary' }}>
+                                            {searchQuery
+                                                ? t('settings.users.noSearchResults')
+                                                : t('common.noData')}
+                                        </TableCell>
+                                    </TableRow>
+                                ) : (
+                                    users.map((user) => {
+                                        // Compute display role: globalRole > COMPANY_ADMIN/SUPER_USER > STORE_ADMIN > storeRole > companyRole > fallback
+                                        const firstStore = user.stores?.[0];
+                                        const firstCompany = user.companies?.[0];
+                                        const companyRole = firstCompany?.role;
+                                        const isAdminCompanyRole = companyRole === 'COMPANY_ADMIN' || companyRole === 'SUPER_USER';
+                                        const isAllStoresRole = isAdminCompanyRole;
+                                        const userRole = user.globalRole
+                                            || (isAdminCompanyRole ? 'COMPANY_ADMIN' : null)
+                                            || firstStore?.role
+                                            || companyRole
+                                            || 'STORE_VIEWER';
+                                        const isAdminLevel = user.globalRole === 'PLATFORM_ADMIN' || isAllStoresRole;
+                                        const userFeatures = isAdminLevel
+                                            ? ['dashboard', 'spaces', 'conference', 'people']
+                                            : (firstStore?.features || ['dashboard']);
+                                        const canElevate = isPlatformAdmin &&
+                                            user.globalRole !== 'PLATFORM_ADMIN' &&
+                                            user.id !== currentUser?.id;
+
+                                        return (
+                                            <TableRow key={user.id} hover>
+                                                <TableCell>
+                                                    <Typography variant="body2" noWrap sx={{ maxWidth: { xs: 120, sm: 180 } }}>
+                                                        {user.email}
+                                                    </Typography>
+                                                </TableCell>
+                                                <TableCell sx={{ display: { xs: 'none', sm: 'table-cell' } }}>
+                                                    {user.firstName || user.lastName
+                                                        ? <Typography variant="body2" noWrap>{`${user.firstName || ''} ${user.lastName || ''}`.trim()}</Typography>
+                                                        : <Typography variant="body2" color="text.secondary">—</Typography>
+                                                    }
+                                                </TableCell>
+                                                <TableCell>
+                                                    <Chip
+                                                        label={t(`roles.${userRole.toLowerCase()}`)}
+                                                        color={getRoleColor(userRole) as any}
+                                                        variant='filled'
+                                                        size="small"
+                                                        sx={{ p: 1, px: 1.5 }}
+                                                    />
+                                                </TableCell>
+                                                <TableCell sx={{ display: { xs: 'none', md: 'table-cell' } }}>
+                                                    <Stack direction="row" gap={0.5} flexWrap="wrap">
+                                                        {userFeatures.map(feature => (
+                                                            <Tooltip key={feature} title={t(`navigation.${feature}`)}>
+                                                                <span style={{ fontSize: '1.1rem' }}>
+                                                                    {getFeatureIcon(feature)}
+                                                                </span>
+                                                            </Tooltip>
+                                                        ))}
+                                                    </Stack>
+                                                </TableCell>
+                                                <TableCell>
+                                                    <Chip
+                                                        label={user.isActive ? t('common.status.active') : t('common.status.inactive')}
+                                                        color={user.isActive ? 'success' : 'default'}
+                                                        variant="outlined"
+                                                        size="small"
+                                                        sx={{ p: 1, px: 1.5 }}
+                                                    />
+                                                </TableCell>
+                                                <TableCell align="right">
+                                                    <Stack direction="row" justifyContent="flex-end" gap={0.5}>
+                                                        {/* Elevate Button (Platform Admin only) */}
+                                                        {canElevate && (
+                                                            <Tooltip title={t('settings.users.elevate')}>
+                                                                <IconButton
+                                                                    onClick={() => handleElevate(user)}
+                                                                    size="small"
+                                                                    color="warning"
+                                                                >
+                                                                    <AdminPanelSettingsIcon fontSize="small" />
+                                                                </IconButton>
+                                                            </Tooltip>
+                                                        )}
+                                                        <Tooltip title={t('common.edit')}>
+                                                            <IconButton onClick={() => handleEdit(user)} size="small" color="primary">
+                                                                <EditIcon fontSize="small" />
+                                                            </IconButton>
+                                                        </Tooltip>
+                                                        <Tooltip title={t('common.delete')}>
+                                                            <span>
+                                                                <IconButton
+                                                                    onClick={() => handleDelete(user)}
+                                                                    size="small"
+                                                                    color="error"
+                                                                    disabled={user.id === currentUser?.id} // Cannot delete self
+                                                                >
+                                                                    <DeleteIcon fontSize="small" />
+                                                                </IconButton>
                                                             </span>
                                                         </Tooltip>
-                                                    ))}
-                                                </Stack>
-                                            </TableCell>
-                                            <TableCell>
-                                                <Chip
-                                                    label={user.isActive ? t('common.status.active') : t('common.status.inactive')}
-                                                    color={user.isActive ? 'success' : 'default'}
-                                                    variant="outlined"
-                                                    size="small"
-                                                    sx={{ p: 1 }}
-                                                />
-                                            </TableCell>
-                                            <TableCell align="right">
-                                                <Stack direction="row" justifyContent="flex-end" gap={0.5}>
-                                                    {/* Elevate Button (Platform Admin only) */}
-                                                    {canElevate && (
-                                                        <Tooltip title={t('settings.users.elevate')}>
-                                                            <IconButton 
-                                                                onClick={() => handleElevate(user)} 
-                                                                size="small" 
-                                                                color="warning"
-                                                            >
-                                                                <AdminPanelSettingsIcon fontSize="small" />
-                                                            </IconButton>
-                                                        </Tooltip>
-                                                    )}
-                                                    <Tooltip title={t('common.edit')}>
-                                                        <IconButton onClick={() => handleEdit(user)} size="small" color="primary">
-                                                            <EditIcon fontSize="small" />
-                                                        </IconButton>
-                                                    </Tooltip>
-                                                    <Tooltip title={t('common.delete')}>
-                                                        <span>
-                                                            <IconButton
-                                                                onClick={() => handleDelete(user)}
-                                                                size="small"
-                                                                color="error"
-                                                                disabled={user.id === currentUser?.id} // Cannot delete self
-                                                            >
-                                                                <DeleteIcon fontSize="small" />
-                                                            </IconButton>
-                                                        </span>
-                                                    </Tooltip>
-                                                </Stack>
-                                            </TableCell>
-                                        </TableRow>
-                                    );
-                                })
-                            )}
-                        </TableBody>
-                    </Table>
-                </TableContainer>
-                <TablePagination
-                    component="div"
-                    count={total}
-                    page={page}
-                    onPageChange={(_, newPage) => setPage(newPage)}
-                    rowsPerPage={limit}
-                    onRowsPerPageChange={(e) => {
-                        setLimit(parseInt(e.target.value, 10));
-                        setPage(0);
-                    }}
-                    rowsPerPageOptions={[5, 10, 25, 50]}
-                    labelRowsPerPage={t('common.rowsPerPage')}
-                    sx={{
-                        '.MuiTablePagination-selectLabel, .MuiTablePagination-displayedRows': {
-                            margin: 0,
-                        },
-                        '.MuiTablePagination-toolbar': {
-                            flexWrap: 'wrap',
-                            justifyContent: 'center',
-                            gap: 1,
-                        },
-                    }}
-                />
-            </Paper>
+                                                    </Stack>
+                                                </TableCell>
+                                            </TableRow>
+                                        );
+                                    })
+                                )}
+                            </TableBody>
+                        </Table>
+                    </TableContainer>
+                    <TablePagination
+                        component="div"
+                        count={total}
+                        page={page}
+                        onPageChange={(_, newPage) => setPage(newPage)}
+                        rowsPerPage={limit}
+                        onRowsPerPageChange={(e) => {
+                            setLimit(parseInt(e.target.value, 10));
+                            setPage(0);
+                        }}
+                        rowsPerPageOptions={[5, 10, 25, 50]}
+                        labelRowsPerPage={t('common.rowsPerPage')}
+                        sx={{
+                            '.MuiTablePagination-selectLabel, .MuiTablePagination-displayedRows': {
+                                margin: 0,
+                            },
+                            '.MuiTablePagination-toolbar': {
+                                flexWrap: 'wrap',
+                                justifyContent: 'center',
+                                gap: 1,
+                            },
+                        }}
+                    />
+                </Paper>
+            )}
 
             {/* User Dialog */}
             <Suspense fallback={null}>


### PR DESCRIPTION
…ding

Labels page:
- Add px:1 inline padding to signal/battery/status chips
- Change article section label to "Article ID" for clarity
- Simplify mobile filter button to icon-only (remove text)

Settings dialogs — fullScreen on mobile:
- CompanyDialog, EnhancedUserDialog (both edit/create modes), StoreDialog, ElevateUserDialog now use fullScreen={isMobile} with borderRadius:0 for proper mobile display

Settings tables — mobile card views:
- CompaniesTab: enterprise card layout with gradient accent bar, company code chip, name, store count, AIMS status, active status
- StoresDialog: fullScreen + card view with sync status, entity counts, timezone, and last sync timestamp
- UsersSettingsTab: card view with email, name, role chip, status chip, feature icons, and action buttons
- SolumFieldMappingTable: card view with field key, toggle switch for visibility, and inline text fields for EN/HE names

All chips across settings components now use px:1.5 for extra inline padding for better readability on mobile.

https://claude.ai/code/session_017hJU2ASFv1wVm6QdaZp5eh