### PR TITLE
fix: resolve TS build errors in SecuritySettingsTab

### DIFF
--- a/src/features/settings/presentation/SecuritySettingsTab.tsx
+++ b/src/features/settings/presentation/SecuritySettingsTab.tsx
@@ -83,7 +83,7 @@ const getDeviceOS = (deviceName: string | null | undefined): string | null => {
     return null;
 };
 
-const formatRelativeDate = (dateStr: string, t: (key: string, fallback?: string) => string): string => {
+const formatRelativeDate = (dateStr: string, t: (key: string, defaultValue: string) => string): string => {
     try {
         const now = new Date();
         const date = new Date(dateStr);
@@ -113,7 +113,7 @@ export function SecuritySettingsTab({
     onUnlock,
     onUpdate,
 }: SecuritySettingsTabProps) {
-    const { t, i18n } = useTranslation();
+    const { t } = useTranslation();
     const { confirm, ConfirmDialog } = useConfirmDialog();
     const [newPassword, setNewPassword] = useState('');
     const [confirmPassword, setConfirmPassword] = useState('');


### PR DESCRIPTION
## Summary
- Removes unused `i18n` import from `SecuritySettingsTab` main component (TS6133)
- Fixes `formatRelativeDate` TFunction signature — changes optional `fallback?` parameter to required `defaultValue` to match i18next's `TFunction` type (TS2345)

**Hotfix for broken CI/CD deploy after #73 merge.**

## Test plan
- [ ] Docker build completes without TypeScript errors
- [ ] Device cards render correctly in Security & Devices tab
- [ ] Relative date formatting still works (just now / minutes ago / hours ago / days ago)

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>