### PR TITLE
fix: sync AVAILABLE_FEATURES to fix 400 on store role assignment

### DIFF
--- a/server/src/features/users/types.ts
+++ b/server/src/features/users/types.ts
@@ -10,7 +10,7 @@ import { GlobalRole, CompanyRole } from '@prisma/client';
 // Constants
 // ======================
 
-export const AVAILABLE_FEATURES = ['dashboard', 'spaces', 'conference', 'people', 'sync', 'settings', 'labels'] as const;
+export const AVAILABLE_FEATURES = ['dashboard', 'spaces', 'conference', 'people', 'sync', 'settings', 'labels', 'aims-management'] as const;
 export type Feature = typeof AVAILABLE_FEATURES[number];
 
 const COMPANY_CODE_REGEX = /^[A-Z]{3,}$/;

--- a/src/features/settings/presentation/StoreAssignment.tsx
+++ b/src/features/settings/presentation/StoreAssignment.tsx
@@ -36,6 +36,7 @@ const AVAILABLE_FEATURES = [
     { id: 'spaces', icon: '🏷️' },
     { id: 'conference', icon: '🎤' },
     { id: 'people', icon: '👥' },
+    { id: 'labels', icon: '🏷️' },
     { id: 'aims-management', icon: '📡' },
     { id: 'sync', icon: '🔄' },
     { id: 'settings', icon: '⚙️' },


### PR DESCRIPTION
## Summary
- Synced `AVAILABLE_FEATURES` between client and server — both now include all 8 features
- Server was missing `aims-management`, causing Zod validation 400 when assigning users to stores
- Client was missing `labels` feature toggle in StoreAssignment UI

Closes #84

## Root Cause
`AVAILABLE_FEATURES` in `server/src/features/users/types.ts` had 7 features (missing `aims-management`), while the client `StoreAssignment.tsx` had 7 features (missing `labels`). When the client sent `aims-management` in the features array, the server Zod enum rejected it with 400.

## Changes
- `server/src/features/users/types.ts`: Added `aims-management` to AVAILABLE_FEATURES
- `src/features/settings/presentation/StoreAssignment.tsx`: Added `labels` to AVAILABLE_FEATURES

## Test plan
- [x] Server TypeScript build passes
- [x] Client TypeScript build passes
- [x] Server unit tests pass (87/87)
- [x] Client unit tests pass (1232/1232)
- [ ] Manual test: assign user to store with Manager role in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)