### PR TITLE
fix: stabilize AIMS gateway/label fetching

### DIFF
--- a/src/features/aims-management/application/useGateways.ts
+++ b/src/features/aims-management/application/useGateways.ts
@@ -11,7 +11,7 @@ const STALE_TIME = 30_000; // 30 seconds
 
 export function useGateways(storeId: string | null) {
     const {
-        gateways, gatewaysLoading, gatewaysError, gatewaysLastFetched,
+        gateways, gatewaysLoading, gatewaysError,
         setGateways, setGatewaysLoading, setGatewaysError,
         selectedGateway, selectedGatewayLoading,
         setSelectedGateway, setSelectedGatewayLoading,
@@ -23,8 +23,9 @@ export function useGateways(storeId: string | null) {
 
     const fetchGateways = useCallback(async (force = false) => {
         if (!storeId) return;
-        if (!force && gatewaysLastFetched && Date.now() - gatewaysLastFetched < STALE_TIME) return;
-        
+        const { gatewaysLastFetched: lastFetched } = useAimsManagementStore.getState();
+        if (!force && lastFetched && Date.now() - lastFetched < STALE_TIME) return;
+
         setGatewaysLoading(true);
         setGatewaysError(null);
         try {
@@ -36,7 +37,7 @@ export function useGateways(storeId: string | null) {
         } finally {
             setGatewaysLoading(false);
         }
-    }, [storeId, gatewaysLastFetched, setGateways, setGatewaysLoading, setGatewaysError]);
+    }, [storeId, setGateways, setGatewaysLoading, setGatewaysError]);
 
     const fetchGatewayDetail = useCallback(async (mac: string) => {
         if (!storeId) return;

--- a/src/features/aims-management/application/useLabelsOverview.ts
+++ b/src/features/aims-management/application/useLabelsOverview.ts
@@ -11,7 +11,7 @@ const STALE_TIME = 30_000; // 30 seconds
 
 export function useLabelsOverview(storeId: string | null) {
     const {
-        labels, labelsLoading, labelsError, labelsLastFetched,
+        labels, labelsLoading, labelsError,
         setLabels, setLabelsLoading, setLabelsError,
         unassignedLabels, unassignedLabelsLoading,
         setUnassignedLabels, setUnassignedLabelsLoading,
@@ -19,6 +19,7 @@ export function useLabelsOverview(storeId: string | null) {
 
     const fetchLabels = useCallback(async (force = false) => {
         if (!storeId) return;
+        const { labelsLastFetched } = useAimsManagementStore.getState();
         if (!force && labelsLastFetched && Date.now() - labelsLastFetched < STALE_TIME) return;
 
         setLabelsLoading(true);
@@ -32,7 +33,7 @@ export function useLabelsOverview(storeId: string | null) {
         } finally {
             setLabelsLoading(false);
         }
-    }, [storeId, labelsLastFetched, setLabels, setLabelsLoading, setLabelsError]);
+    }, [storeId, setLabels, setLabelsLoading, setLabelsError]);
 
     const fetchUnassignedLabels = useCallback(async () => {
         if (!storeId) return;

--- a/src/features/aims-management/presentation/AimsManagementPage.tsx
+++ b/src/features/aims-management/presentation/AimsManagementPage.tsx
@@ -5,7 +5,7 @@
  * Follows the same layout pattern as ConferencePage and other feature pages.
  */
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import {
     Box, Typography, Tabs, Tab, Button, Alert, Stack, Card, CardContent,
     Fab, useMediaQuery, useTheme,
@@ -53,17 +53,18 @@ export function AimsManagementPage() {
     const { gateways, fetchGateways } = useGateways(activeStoreId);
     const { stats: labelStats, fetchLabels } = useLabelsOverview(activeStoreId);
 
-    // Reset store when store changes
+    // Reset store and re-fetch when store changes
+    const prevStoreRef = useRef(activeStoreId);
     useEffect(() => {
-        reset();
-    }, [activeStoreId, reset]);
-
-    // Fetch labels for the stats card
-    useEffect(() => {
+        if (prevStoreRef.current !== activeStoreId) {
+            reset();
+            prevStoreRef.current = activeStoreId;
+        }
         if (activeStoreId) {
+            fetchGateways();
             fetchLabels();
         }
-    }, [activeStoreId, fetchLabels]);
+    }, [activeStoreId, reset, fetchGateways, fetchLabels]);
 
     // Stats
     const { onlineCount, offlineCount } = useMemo(() => {


### PR DESCRIPTION
## Summary
- **Fix AIMS gateway/label data not displaying**: The `useGateways` and `useLabelsOverview` hooks had `lastFetched` timestamps as `useCallback` dependencies, causing callback identity churn on every fetch — the same dependency cycle pattern as the auth watchdog bug fixed in #87
- **Fix reset() race condition**: `AimsManagementPage` called `reset()` on initial mount, clearing data that child components had just started fetching. Now only resets on actual store change (tracked via `useRef`)

## Root Cause
1. `fetchGateways` depended on `gatewaysLastFetched` → every successful fetch gave the callback a new identity → `GatewayList`'s `useEffect` re-fired
2. `reset()` ran on mount (parent effect, after child effects) → cleared `gatewaysLoading` and `gateways` right after `GatewayList` started its fetch → showed empty "no gateways" state

## Changes (3 files)
- `useGateways.ts`: Read `gatewaysLastFetched` via `getState()` instead of reactive dependency
- `useLabelsOverview.ts`: Same `getState()` fix for `labelsLastFetched`
- `AimsManagementPage.tsx`: Drive `fetchGateways()`/`fetchLabels()` from parent effect; only `reset()` on actual store ID change via `useRef`

## Test plan
- [x] `npx tsc -b` — client compiles clean
- [x] `npx vitest run` — 1232 client tests pass
- [ ] Manual: Navigate to AIMS Management → verify gateways load on first render
- [ ] Manual: Switch stores → verify data resets and reloads for new store

🤖 Generated with [Claude Code](https://claude.com/claude-code)