### PR TITLE
fix: grant AIMS management access to managers

### DIFF
--- a/src/features/auth/application/permissionHelpers.ts
+++ b/src/features/auth/application/permissionHelpers.ts
@@ -208,6 +208,15 @@ export function canAccessFeature(
     // Store admins have access to all enabled features (check roleId first)
     if (store.roleId === DEFAULT_ROLE_IDS.ADMIN || store.role === 'STORE_ADMIN') return true;
 
+    // aims-management is a company-level feature (aimsManagementEnabled toggle).
+    // Access is role-gated (STORE_MANAGER+), not per-user feature whitelisted.
+    // The company toggle was already validated by isFeatureEnabled above.
+    if (feature === 'aims-management') {
+        const roleLevel = ROLE_ID_HIERARCHY[store.roleId ?? ''] ?? 0;
+        const legacyLevel = STORE_ROLE_HIERARCHY[store.role ?? ''] ?? 0;
+        return Math.max(roleLevel, legacyLevel) >= STORE_ROLE_HIERARCHY['STORE_MANAGER'];
+    }
+
     // Check feature list for other roles
     return store.features.includes(feature);
 }


### PR DESCRIPTION
## Summary
- **Root cause**: `canAccessFeature('aims-management')` returned `false` for manager-role users because the function's fallback checks `store.features.includes('aims-management')`, but managers' `store.features` array only contains `['dashboard']` — the default set when they were assigned to the store before `aims-management` existed as a feature
- **Fix**: Added a special case in `canAccessFeature()` for `aims-management` that checks the user's role level (STORE_MANAGER+) instead of the per-user `store.features` whitelist. The company-level toggle (`aimsManagementEnabled`) is already validated earlier in the function
- This made both the navigation tab and the route content invisible/inaccessible to non-admin users

## Test plan
- [ ] Log in as a manager-role user with a store that has `aimsManagementEnabled: true`
- [ ] Verify the AIMS Management nav tab is visible
- [ ] Navigate to AIMS Management and verify gateways load
- [ ] Verify admin users still have full access
- [ ] Verify viewer-role users do NOT see the AIMS Management tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)