### PR TITLE
fix: parse SoluM gateway response correctly

### DIFF
--- a/server/src/shared/infrastructure/services/solumService.ts
+++ b/server/src/shared/infrastructure/services/solumService.ts
@@ -666,7 +666,8 @@ export class SolumService {
         const url = this.buildUrl(config, `/common/api/v2/common/gateway?company=${config.companyName}&store=${config.storeCode}`);
         return this.withRetry('fetchGateways', async () => {
             const response = await this.client.get(url, { headers: { 'Authorization': `Bearer ${token}` } });
-            return response.data?.responseMessage ?? response.data ?? [];
+            // SoluM returns { gatewayList: [...], responseMessage: "OK" }
+            return response.data?.gatewayList ?? response.data?.responseMessage ?? response.data ?? [];
         });
     }
 
@@ -675,7 +676,9 @@ export class SolumService {
         const url = this.buildUrl(config, `/common/api/v2/common/gateway/detail?company=${config.companyName}&store=${config.storeCode}&gateway=${gatewayMac}`);
         return this.withRetry('fetchGatewayDetail', async () => {
             const response = await this.client.get(url, { headers: { 'Authorization': `Bearer ${token}` } });
-            return response.data?.responseMessage ?? response.data ?? {};
+            // SoluM returns gateway detail as flat object with responseCode/responseMessage fields
+            const { responseCode, responseMessage, ...detail } = response.data ?? {};
+            return Object.keys(detail).length > 0 ? detail : response.data ?? {};
         });
     }
 
@@ -683,7 +686,8 @@ export class SolumService {
         const url = this.buildUrl(config, `/common/api/v2/common/gateway/floating?company=${config.companyName}`);
         return this.withRetry('fetchFloatingGateways', async () => {
             const response = await this.client.get(url, { headers: { 'Authorization': `Bearer ${token}` } });
-            return response.data?.responseMessage ?? response.data ?? [];
+            // SoluM may return { gatewayList: [...] } or { responseMessage: [...] }
+            return response.data?.gatewayList ?? response.data?.responseMessage ?? response.data ?? [];
         });
     }
 
@@ -723,7 +727,9 @@ export class SolumService {
         const url = this.buildUrl(config, `/common/api/v2/common/gateway/debug/info?company=${config.companyName}&store=${config.storeCode}&gateway=${gatewayMac}`);
         return this.withRetry('fetchGatewayDebugReport', async () => {
             const response = await this.client.get(url, { headers: { 'Authorization': `Bearer ${token}` } });
-            return response.data?.responseMessage ?? response.data ?? {};
+            // Strip metadata fields, return the actual debug data
+            const { responseCode, responseMessage, ...report } = response.data ?? {};
+            return Object.keys(report).length > 0 ? report : response.data ?? {};
         });
     }
 

--- a/src/features/aims-management/presentation/AimsManagementPage.tsx
+++ b/src/features/aims-management/presentation/AimsManagementPage.tsx
@@ -68,7 +68,10 @@ export function AimsManagementPage() {
 
     // Stats
     const { onlineCount, offlineCount } = useMemo(() => {
-        const online = gateways.filter((g: any) => g.status === 'ONLINE' || g.status === 'online').length;
+        const online = gateways.filter((g: any) => {
+            const status = (g.status || g.networkStatus || '').toUpperCase();
+            return status === 'ONLINE' || status === 'CONNECTED';
+        }).length;
         return { onlineCount: online, offlineCount: gateways.length - online };
     }, [gateways]);
 

--- a/src/features/aims-management/presentation/GatewayList.tsx
+++ b/src/features/aims-management/presentation/GatewayList.tsx
@@ -62,7 +62,10 @@ export function GatewayList({ storeId, onSelectGateway }: GatewayListProps) {
         return <Alert severity="error" action={<Button onClick={() => fetchGateways(true)}>{t('common.retry')}</Button>}>{gatewaysError}</Alert>;
     }
 
-    const onlineCount = gateways.filter((g: any) => g.status === 'ONLINE' || g.status === 'online').length;
+    const onlineCount = gateways.filter((g: any) => {
+        const status = (g.status || g.networkStatus || '').toUpperCase();
+        return status === 'ONLINE' || status === 'CONNECTED';
+    }).length;
 
     if (gateways.length === 0) {
         return (
@@ -106,7 +109,8 @@ export function GatewayList({ storeId, onSelectGateway }: GatewayListProps) {
                     <TableBody>
                         {gateways.map((gw: any) => {
                             const mac = gw.mac || gw.macAddress || gw.gatewayId || '';
-                            const isOnline = gw.status === 'ONLINE' || gw.status === 'online';
+                            const statusRaw = (gw.status || gw.networkStatus || '').toUpperCase();
+                            const isOnline = statusRaw === 'ONLINE' || statusRaw === 'CONNECTED';
                             return (
                                 <TableRow key={mac} hover>
                                     <TableCell><Typography variant="body2" fontFamily="monospace">{mac}</Typography></TableCell>
@@ -120,8 +124,8 @@ export function GatewayList({ storeId, onSelectGateway }: GatewayListProps) {
                                         />
                                     </TableCell>
                                     <TableCell>{gw.model || '\u2014'}</TableCell>
-                                    <TableCell>{gw.firmwareVersion || '\u2014'}</TableCell>
-                                    <TableCell align="right">{gw.connectedLabelCount ?? '\u2014'}</TableCell>
+                                    <TableCell>{gw.firmwareVersion || gw.version || '\u2014'}</TableCell>
+                                    <TableCell align="right">{gw.connectedLabelCount ?? gw.labelCount ?? '\u2014'}</TableCell>
                                     <TableCell align="right">
                                         <Tooltip title={t('aims.viewDetails')}>
                                             <IconButton size="small" onClick={() => onSelectGateway?.(mac)}>


### PR DESCRIPTION
## Summary
- **Server**: `solumService.fetchGateways()` was returning `"OK"` (string) instead of the gateway array. SoluM's gateway endpoint returns `{ gatewayList: [...], responseMessage: "OK" }` — the actual data is in `gatewayList`, not `responseMessage`. Fixed `fetchGateways`, `fetchGatewayDetail`, `fetchFloatingGateways`, and `fetchGatewayDebugReport`.
- **Client**: `GatewayList.tsx` and `AimsManagementPage.tsx` checked `g.status === 'ONLINE'` but SoluM returns `networkStatus: "CONNECTED"`. Also aligned field name fallbacks for `version`/`firmwareVersion` and `labelCount`/`connectedLabelCount`.

## Root Cause
Diagnosed by running a diagnostic script inside the production Docker container that called the SoluM API directly and inspected the actual response shape.

## Test plan
- [ ] Deploy and verify AIMS Management page shows gateways with correct status chips
- [ ] Verify gateway online/offline counts match reality
- [ ] Verify firmware version and label count columns display data

🤖 Generated with [Claude Code](https://claude.com/claude-code)