### PR TITLE
feat: AIMS responsive gateway cards + dashboard widget

### DIFF
--- a/server/src/shared/infrastructure/services/solumService.ts
+++ b/server/src/shared/infrastructure/services/solumService.ts
@@ -754,7 +754,7 @@ export class SolumService {
         if (toDate) url += `&toDate=${toDate}`;
         return this.withRetry('fetchBatchHistory', async () => {
             const response = await this.client.get(url, { headers: { 'Authorization': `Bearer ${token}` } });
-            return this.extractResponseData(response.data);
+            return this.extractResponseData(response.data, 'fetchBatchHistory');
         });
     }
 
@@ -763,7 +763,7 @@ export class SolumService {
         const url = this.buildUrl(config, `/common/api/v2/common/articles/history/detail?company=${config.companyName}&store=${config.storeCode}&name=${encodeURIComponent(batchName)}`);
         return this.withRetry('fetchBatchDetail', async () => {
             const response = await this.client.get(url, { headers: { 'Authorization': `Bearer ${token}` } });
-            return this.extractResponseData(response.data);
+            return this.extractResponseData(response.data, 'fetchBatchDetail');
         });
     }
 
@@ -772,7 +772,7 @@ export class SolumService {
         const url = this.buildUrl(config, `/common/api/v2/common/articles/validationerror/logs?company=${config.companyName}&store=${config.storeCode}&batchId=${batchId}`);
         return this.withRetry('fetchBatchErrors', async () => {
             const response = await this.client.get(url, { headers: { 'Authorization': `Bearer ${token}` } });
-            return this.extractResponseData(response.data);
+            return this.extractResponseData(response.data, 'fetchBatchErrors');
         });
     }
 
@@ -781,25 +781,37 @@ export class SolumService {
         const url = this.buildUrl(config, `/common/api/v2/common/articles/update/history?company=${config.companyName}&store=${config.storeCode}&article=${encodeURIComponent(articleId)}&page=${page}&size=${size}`);
         return this.withRetry('fetchArticleUpdateHistory', async () => {
             const response = await this.client.get(url, { headers: { 'Authorization': `Bearer ${token}` } });
-            return this.extractResponseData(response.data);
+            return this.extractResponseData(response.data, 'fetchArticleUpdateHistory');
         });
     }
 
     /**
      * Extract data from AIMS API response.
-     * AIMS responses vary: sometimes data is in responseMessage (object/array),
-     * sometimes responseMessage is just "SUCCESS" and data is in a separate field.
+     * SoluM responses vary by endpoint:
+     *   - Gateway list: { gatewayList: [...], responseCode, responseMessage: "OK" }
+     *   - History/paginated: { content: [...], totalPages, totalElements, ..., responseCode, responseMessage }
+     *   - Detail: flat object with responseCode/responseMessage mixed in
+     *   - Some: responseMessage IS the data (object/array)
      */
-    private extractResponseData(data: any): any {
+    private extractResponseData(data: any, context?: string): any {
         if (!data) return {};
-        // If responseMessage is an object/array, it IS the data (gateway endpoints)
+
+        // Log full response shape for debugging SoluM endpoint variations
+        const keys = Object.keys(data);
+        appLogger.debug('SolumService', `extractResponseData [${context ?? '?'}] keys=${keys.join(',')} rmType=${typeof data.responseMessage}`);
+
+        // If responseMessage is an object/array, it IS the data
         if (data.responseMessage && typeof data.responseMessage === 'object') {
             return data.responseMessage;
         }
-        // Otherwise look for data.data or data.content (article/history endpoints)
-        if (data.data) return data.data;
-        if (data.content) return data;
-        // Fallback: return the whole response minus status fields
+        // Paginated endpoints return { content: [...], totalPages, totalElements, ... }
+        if (Array.isArray(data.content)) {
+            const { responseCode, responseMessage, ...paginated } = data;
+            return paginated;
+        }
+        // Some endpoints nest under data.data
+        if (data.data !== undefined) return data.data;
+        // Strip metadata fields and return the rest
         const { responseCode, responseMessage, ...rest } = data;
         return Object.keys(rest).length > 0 ? rest : data;
     }

--- a/src/features/aims-management/presentation/GatewayList.tsx
+++ b/src/features/aims-management/presentation/GatewayList.tsx
@@ -1,21 +1,23 @@
 /**
  * Gateway List Component
  *
- * Displays gateways in a table with status indicators.
- * Follows the same data display patterns as other feature pages.
+ * Displays gateways in a table (desktop) or card layout (mobile).
+ * Follows the same responsive patterns as PeopleTable and ConferencePage.
  */
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import {
     Box, Table, TableBody, TableCell, TableContainer, TableHead, TableRow,
     Paper, Typography, Chip, IconButton, Tooltip, Alert, Button,
-    Card, CardContent, Skeleton,
+    Card, CardContent, Skeleton, Stack, useMediaQuery, useTheme, Collapse,
 } from '@mui/material';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import InfoIcon from '@mui/icons-material/Info';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import DeleteIcon from '@mui/icons-material/Delete';
 import RouterIcon from '@mui/icons-material/Router';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import { useTranslation } from 'react-i18next';
 import { useGateways } from '../application/useGateways';
 import { useGatewayManagement } from '../application/useGatewayManagement';
@@ -26,13 +28,28 @@ interface GatewayListProps {
     onSelectGateway?: (mac: string) => void;
 }
 
+function getGatewayFields(gw: any) {
+    const mac = gw.mac || gw.macAddress || gw.gatewayId || '';
+    const statusRaw = (gw.status || gw.networkStatus || '').toUpperCase();
+    const isOnline = statusRaw === 'ONLINE' || statusRaw === 'CONNECTED';
+    const ip = gw.ip || gw.ipAddress || '\u2014';
+    const model = gw.model || '\u2014';
+    const firmware = gw.firmwareVersion || gw.version || '\u2014';
+    const labelCount = gw.connectedLabelCount ?? gw.labelCount ?? '\u2014';
+    return { mac, statusRaw, isOnline, ip, model, firmware, labelCount };
+}
+
 export function GatewayList({ storeId, onSelectGateway }: GatewayListProps) {
     const { t } = useTranslation();
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('md'));
     const { hasStoreRole } = useAuthContext();
     const canManage = hasStoreRole('STORE_ADMIN');
 
     const { gateways, gatewaysLoading, gatewaysError, fetchGateways } = useGateways(storeId);
     const { rebootGateway, deregisterGateways, loading: actionLoading } = useGatewayManagement(storeId);
+
+    const [expandedMac, setExpandedMac] = useState<string | null>(null);
 
     useEffect(() => { fetchGateways(); }, [fetchGateways]);
 
@@ -52,7 +69,7 @@ export function GatewayList({ storeId, onSelectGateway }: GatewayListProps) {
         return (
             <Box>
                 {[1, 2, 3].map((i) => (
-                    <Skeleton key={i} variant="rectangular" height={52} sx={{ mb: 1, borderRadius: 1 }} />
+                    <Skeleton key={i} variant="rectangular" height={isMobile ? 80 : 52} sx={{ mb: 1, borderRadius: 1 }} />
                 ))}
             </Box>
         );
@@ -93,66 +110,161 @@ export function GatewayList({ storeId, onSelectGateway }: GatewayListProps) {
                 </Tooltip>
             </Box>
 
-            <TableContainer component={Paper} variant="outlined">
-                <Table size="small">
-                    <TableHead>
-                        <TableRow>
-                            <TableCell>{t('aims.macAddress')}</TableCell>
-                            <TableCell>{t('aims.ipAddress')}</TableCell>
-                            <TableCell>{t('aims.status')}</TableCell>
-                            <TableCell>{t('aims.model')}</TableCell>
-                            <TableCell>{t('aims.firmware')}</TableCell>
-                            <TableCell align="right">{t('aims.labels')}</TableCell>
-                            <TableCell align="right">{t('aims.actions')}</TableCell>
-                        </TableRow>
-                    </TableHead>
-                    <TableBody>
-                        {gateways.map((gw: any) => {
-                            const mac = gw.mac || gw.macAddress || gw.gatewayId || '';
-                            const statusRaw = (gw.status || gw.networkStatus || '').toUpperCase();
-                            const isOnline = statusRaw === 'ONLINE' || statusRaw === 'CONNECTED';
-                            return (
-                                <TableRow key={mac} hover>
-                                    <TableCell><Typography variant="body2" fontFamily="monospace">{mac}</Typography></TableCell>
-                                    <TableCell>{gw.ip || gw.ipAddress || '\u2014'}</TableCell>
-                                    <TableCell>
+            {isMobile ? (
+                /* ── Mobile: Card-based layout ── */
+                <Stack gap={1.5}>
+                    {gateways.map((gw: any) => {
+                        const { mac, isOnline, ip, model, firmware, labelCount } = getGatewayFields(gw);
+                        const isExpanded = expandedMac === mac;
+
+                        return (
+                            <Card key={mac} variant="outlined">
+                                <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
+                                    {/* Compact header — always visible */}
+                                    <Stack
+                                        direction="row"
+                                        alignItems="center"
+                                        gap={1}
+                                        onClick={() => setExpandedMac(isExpanded ? null : mac)}
+                                        sx={{ cursor: 'pointer' }}
+                                    >
                                         <Chip
                                             label={isOnline ? t('aims.online') : t('aims.offline')}
                                             color={isOnline ? 'success' : 'error'}
                                             size="small"
                                             variant="outlined"
                                         />
-                                    </TableCell>
-                                    <TableCell>{gw.model || '\u2014'}</TableCell>
-                                    <TableCell>{gw.firmwareVersion || gw.version || '\u2014'}</TableCell>
-                                    <TableCell align="right">{gw.connectedLabelCount ?? gw.labelCount ?? '\u2014'}</TableCell>
-                                    <TableCell align="right">
-                                        <Tooltip title={t('aims.viewDetails')}>
-                                            <IconButton size="small" onClick={() => onSelectGateway?.(mac)}>
-                                                <InfoIcon fontSize="small" />
-                                            </IconButton>
-                                        </Tooltip>
-                                        {canManage && (
-                                            <>
-                                                <Tooltip title={t('aims.reboot')}>
-                                                    <IconButton size="small" onClick={() => handleReboot(mac)} disabled={actionLoading}>
-                                                        <RestartAltIcon fontSize="small" />
-                                                    </IconButton>
-                                                </Tooltip>
-                                                <Tooltip title={t('aims.deregister')}>
-                                                    <IconButton size="small" onClick={() => handleDeregister(mac)} disabled={actionLoading} color="error">
-                                                        <DeleteIcon fontSize="small" />
-                                                    </IconButton>
-                                                </Tooltip>
-                                            </>
-                                        )}
-                                    </TableCell>
-                                </TableRow>
-                            );
-                        })}
-                    </TableBody>
-                </Table>
-            </TableContainer>
+                                        <Typography variant="body2" fontFamily="monospace" sx={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                                            {mac}
+                                        </Typography>
+                                        {isExpanded ? <ExpandLessIcon fontSize="small" color="action" /> : <ExpandMoreIcon fontSize="small" color="action" />}
+                                    </Stack>
+
+                                    {/* Expanded details */}
+                                    <Collapse in={isExpanded}>
+                                        <Box sx={{ mt: 1.5, pt: 1.5, borderTop: '1px solid', borderColor: 'divider' }}>
+                                            {/* 2-column field grid */}
+                                            <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 1.5, mb: 1.5 }}>
+                                                <Box>
+                                                    <Typography variant="caption" color="text.secondary">{t('aims.ipAddress')}</Typography>
+                                                    <Typography variant="body2">{ip}</Typography>
+                                                </Box>
+                                                <Box>
+                                                    <Typography variant="caption" color="text.secondary">{t('aims.model')}</Typography>
+                                                    <Typography variant="body2">{model}</Typography>
+                                                </Box>
+                                                <Box>
+                                                    <Typography variant="caption" color="text.secondary">{t('aims.firmware')}</Typography>
+                                                    <Typography variant="body2">{firmware}</Typography>
+                                                </Box>
+                                                <Box>
+                                                    <Typography variant="caption" color="text.secondary">{t('aims.labels')}</Typography>
+                                                    <Typography variant="body2">{labelCount}</Typography>
+                                                </Box>
+                                            </Box>
+
+                                            {/* Action buttons */}
+                                            <Stack direction="row" gap={1} flexWrap="wrap">
+                                                <Button
+                                                    size="medium"
+                                                    variant="outlined"
+                                                    startIcon={<InfoIcon />}
+                                                    onClick={() => onSelectGateway?.(mac)}
+                                                >
+                                                    {t('aims.viewDetails')}
+                                                </Button>
+                                                {canManage && (
+                                                    <>
+                                                        <Button
+                                                            size="medium"
+                                                            variant="outlined"
+                                                            startIcon={<RestartAltIcon />}
+                                                            onClick={() => handleReboot(mac)}
+                                                            disabled={actionLoading}
+                                                        >
+                                                            {t('aims.reboot')}
+                                                        </Button>
+                                                        <Button
+                                                            size="medium"
+                                                            variant="outlined"
+                                                            color="error"
+                                                            startIcon={<DeleteIcon />}
+                                                            onClick={() => handleDeregister(mac)}
+                                                            disabled={actionLoading}
+                                                        >
+                                                            {t('aims.deregister')}
+                                                        </Button>
+                                                    </>
+                                                )}
+                                            </Stack>
+                                        </Box>
+                                    </Collapse>
+                                </CardContent>
+                            </Card>
+                        );
+                    })}
+                </Stack>
+            ) : (
+                /* ── Desktop: Table layout ── */
+                <TableContainer component={Paper} variant="outlined">
+                    <Table size="small">
+                        <TableHead>
+                            <TableRow>
+                                <TableCell>{t('aims.macAddress')}</TableCell>
+                                <TableCell>{t('aims.ipAddress')}</TableCell>
+                                <TableCell>{t('aims.status')}</TableCell>
+                                <TableCell>{t('aims.model')}</TableCell>
+                                <TableCell>{t('aims.firmware')}</TableCell>
+                                <TableCell align="right">{t('aims.labels')}</TableCell>
+                                <TableCell align="right">{t('aims.actions')}</TableCell>
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                            {gateways.map((gw: any) => {
+                                const { mac, isOnline, ip, model, firmware, labelCount } = getGatewayFields(gw);
+                                return (
+                                    <TableRow key={mac} hover>
+                                        <TableCell><Typography variant="body2" fontFamily="monospace">{mac}</Typography></TableCell>
+                                        <TableCell>{ip}</TableCell>
+                                        <TableCell>
+                                            <Chip
+                                                label={isOnline ? t('aims.online') : t('aims.offline')}
+                                                color={isOnline ? 'success' : 'error'}
+                                                size="small"
+                                                variant="outlined"
+                                            />
+                                        </TableCell>
+                                        <TableCell>{model}</TableCell>
+                                        <TableCell>{firmware}</TableCell>
+                                        <TableCell align="right">{labelCount}</TableCell>
+                                        <TableCell align="right">
+                                            <Tooltip title={t('aims.viewDetails')}>
+                                                <IconButton size="small" onClick={() => onSelectGateway?.(mac)}>
+                                                    <InfoIcon fontSize="small" />
+                                                </IconButton>
+                                            </Tooltip>
+                                            {canManage && (
+                                                <>
+                                                    <Tooltip title={t('aims.reboot')}>
+                                                        <IconButton size="small" onClick={() => handleReboot(mac)} disabled={actionLoading}>
+                                                            <RestartAltIcon fontSize="small" />
+                                                        </IconButton>
+                                                    </Tooltip>
+                                                    <Tooltip title={t('aims.deregister')}>
+                                                        <IconButton size="small" onClick={() => handleDeregister(mac)} disabled={actionLoading} color="error">
+                                                            <DeleteIcon fontSize="small" />
+                                                        </IconButton>
+                                                    </Tooltip>
+                                                </>
+                                            )}
+                                        </TableCell>
+                                    </TableRow>
+                                );
+                            })}
+                        </TableBody>
+                    </Table>
+                </TableContainer>
+            )}
         </Box>
     );
 }

--- a/src/features/aims-management/presentation/ProductHistory.tsx
+++ b/src/features/aims-management/presentation/ProductHistory.tsx
@@ -77,7 +77,11 @@ export function ProductHistory({ storeId }: ProductHistoryProps) {
 
     // Summary stats
     const summaryStats = useMemo(() => {
-        const batches = Array.isArray(batchHistory?.content) ? batchHistory.content : (Array.isArray(batchHistory) ? batchHistory : []);
+        // SoluM may return paginated { content: [...] }, direct array, or named list field
+    const batches = Array.isArray(batchHistory?.content) ? batchHistory.content
+        : Array.isArray(batchHistory) ? batchHistory
+        : Array.isArray(batchHistory?.batchHistoryList) ? batchHistory.batchHistoryList
+        : [];
         if (batches.length === 0) return null;
 
         const totalBatches = batches.length;
@@ -96,7 +100,11 @@ export function ProductHistory({ storeId }: ProductHistoryProps) {
         return <Alert severity="error">{error}</Alert>;
     }
 
-    const batches = Array.isArray(batchHistory?.content) ? batchHistory.content : (Array.isArray(batchHistory) ? batchHistory : []);
+    // SoluM may return paginated { content: [...] }, direct array, or named list field
+    const batches = Array.isArray(batchHistory?.content) ? batchHistory.content
+        : Array.isArray(batchHistory) ? batchHistory
+        : Array.isArray(batchHistory?.batchHistoryList) ? batchHistory.batchHistoryList
+        : [];
 
     return (
         <Box>

--- a/src/features/dashboard/DashboardPage.tsx
+++ b/src/features/dashboard/DashboardPage.tsx
@@ -11,6 +11,9 @@ import { useSyncContext } from '@features/sync/application/SyncContext';
 import { usePeopleStore } from '@features/people/infrastructure/peopleStore';
 import { useSettingsStore } from '@features/settings/infrastructure/settingsStore';
 import { useAuthStore } from '@features/auth/infrastructure/authStore';
+import { useAuthContext } from '@features/auth/application/useAuthContext';
+import { useGateways } from '@features/aims-management/application/useGateways';
+import { useLabelsOverview } from '@features/aims-management/application/useLabelsOverview';
 import { labelsApi } from '@shared/infrastructure/services/labelsApi';
 
 // Lazy load dialogs - not needed on initial render
@@ -23,6 +26,7 @@ import {
     DashboardSpacesCard,
     DashboardConferenceCard,
     DashboardPeopleCard,
+    DashboardAimsCard,
     DashboardSkeleton,
     QuickActionsPanel,
 } from './components';
@@ -57,15 +61,25 @@ export function DashboardPage() {
     // People store (before useEffect so fetchPeople is available)
     const peopleStore = usePeopleStore();
 
+    // AIMS data (conditionally loaded when feature is enabled)
+    const { canAccessFeature } = useAuthContext();
+    const isAimsEnabled = canAccessFeature('aims-management');
+    const { gateways, fetchGateways: fetchAimsGateways } = useGateways(activeStoreId);
+    const { stats: aimsLabelStats, fetchLabels: fetchAimsLabels } = useLabelsOverview(activeStoreId);
+
     // Fetch all data from server on mount / store switch so dashboard shows real counts
     useEffect(() => {
         if (isAppReady && activeStoreId) {
             spaceController.fetchSpaces();
             conferenceController.fetchRooms();
             peopleStore.fetchPeople();
+            if (isAimsEnabled) {
+                fetchAimsGateways();
+                fetchAimsLabels();
+            }
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isAppReady, activeStoreId]);
+    }, [isAppReady, activeStoreId, isAimsEnabled]);
 
     // Stats - Spaces
     const totalSpaces = spaceController.spaces.length;
@@ -103,6 +117,16 @@ export function DashboardPage() {
         conferenceController.conferenceRooms.reduce((count, r) => count + (r.assignedLabels?.length || 0), 0),
         [conferenceController.conferenceRooms]
     );
+
+    // Stats - AIMS
+    const aimsGatewayStats = useMemo(() => {
+        const total = gateways.length;
+        const online = gateways.filter((g: any) => {
+            const s = (g.status || g.networkStatus || '').toUpperCase();
+            return s === 'ONLINE' || s === 'CONNECTED';
+        }).length;
+        return { total, online, offline: total - online };
+    }, [gateways]);
 
     // Dialogs State
     const [spaceDialogOpen, setSpaceDialogOpen] = useState(false);
@@ -205,6 +229,20 @@ export function DashboardPage() {
                         isMobile={isMobile}
                     />
                 </Grid>
+
+                {/* AIMS Area - Only show when feature is enabled */}
+                {isAimsEnabled && (
+                    <Grid size={{ xs: 12, md: 6 }}>
+                        <DashboardAimsCard
+                            totalGateways={aimsGatewayStats.total}
+                            onlineGateways={aimsGatewayStats.online}
+                            offlineGateways={aimsGatewayStats.offline}
+                            totalLabels={aimsLabelStats.total}
+                            onlineLabels={aimsLabelStats.online}
+                            isMobile={isMobile}
+                        />
+                    </Grid>
+                )}
 
             </Grid>
 

--- a/src/features/dashboard/components/DashboardAimsCard.tsx
+++ b/src/features/dashboard/components/DashboardAimsCard.tsx
@@ -1,0 +1,196 @@
+import { Box, Card, CardContent, Typography, Stack, LinearProgress } from '@mui/material';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import RouterIcon from '@mui/icons-material/Router';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { MobileStatTile } from './MobileStatTile';
+
+interface DashboardAimsCardProps {
+    totalGateways: number;
+    onlineGateways: number;
+    offlineGateways: number;
+    totalLabels: number;
+    onlineLabels: number;
+    isMobile?: boolean;
+}
+
+export function DashboardAimsCard({
+    totalGateways,
+    onlineGateways,
+    offlineGateways,
+    totalLabels,
+    onlineLabels,
+    isMobile,
+}: DashboardAimsCardProps) {
+    const { t } = useTranslation();
+    const navigate = useNavigate();
+
+    const gatewayHealthPercent = totalGateways > 0 ? Math.round((onlineGateways / totalGateways) * 100) : 0;
+
+    if (isMobile) {
+        return (
+            <Card data-testid="aims-card">
+                <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
+                    <Stack
+                        direction="row"
+                        alignItems="center"
+                        gap={1}
+                        onClick={() => navigate('/aims-management')}
+                        sx={{ mb: 2, cursor: 'pointer' }}
+                    >
+                        <RouterIcon color="primary" sx={{ fontSize: 24 }} />
+                        <Typography variant="subtitle1" fontWeight={600} sx={{ flex: 1 }}>
+                            {t('aims.management')}
+                        </Typography>
+                        <ArrowForwardIcon fontSize="small" color="action" />
+                    </Stack>
+
+                    {/* Hero number */}
+                    <Box sx={{ p: 1.5, bgcolor: 'background.default', borderRadius: 2, mb: 2 }}>
+                        <Typography variant="h2" fontWeight={700} color="primary.main">
+                            {totalGateways}
+                        </Typography>
+                        <Typography variant="subtitle2" color="text.secondary">
+                            {t('aims.totalGateways')}
+                        </Typography>
+                    </Box>
+
+                    {/* Gateway health bar */}
+                    <Stack gap={0.5} sx={{ mb: 2 }}>
+                        <Stack direction="row" justifyContent="space-between" alignItems="center">
+                            <Typography variant="subtitle2" color="text.secondary">
+                                {t('aims.online')} {onlineGateways}/{totalGateways}
+                            </Typography>
+                            <Typography variant="subtitle2" fontWeight={600} color="text.secondary">
+                                {gatewayHealthPercent}%
+                            </Typography>
+                        </Stack>
+                        <LinearProgress
+                            variant="determinate"
+                            value={gatewayHealthPercent}
+                            color="success"
+                            sx={{ height: 8, borderRadius: 4 }}
+                        />
+                    </Stack>
+
+                    {/* Stat tiles */}
+                    <Stack direction="row" gap={1} sx={{ mb: 1 }}>
+                        <MobileStatTile
+                            value={onlineGateways}
+                            label={t('aims.online')}
+                            color="success"
+                        />
+                        <MobileStatTile
+                            value={offlineGateways}
+                            label={t('aims.offline')}
+                            color="error"
+                        />
+                    </Stack>
+                    <Stack direction="row" gap={1}>
+                        <MobileStatTile
+                            value={totalLabels}
+                            label={t('aims.totalLabels')}
+                            color="primary"
+                        />
+                        <MobileStatTile
+                            value={onlineLabels}
+                            label={t('aims.onlineLabels')}
+                            color="info"
+                        />
+                    </Stack>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    return (
+        <Card sx={{ height: '100%', position: 'relative', overflow: 'visible' }} data-testid="aims-card">
+            <CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }}>
+                <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1.5 }}>
+                    <Stack direction="row" gap={1} alignItems="center">
+                        <RouterIcon color="primary" sx={{ fontSize: 28 }} />
+                        <Typography variant="h6" fontWeight={600} sx={{ px: 1 }}>
+                            {t('aims.management')}
+                        </Typography>
+                    </Stack>
+                    <Stack
+                        direction="row"
+                        alignItems="center"
+                        gap={0.5}
+                        onClick={() => navigate('/aims-management')}
+                        sx={{ cursor: 'pointer', color: 'primary.main', '&:hover': { textDecoration: 'underline' } }}
+                    >
+                        <Typography variant="body2" color="primary">
+                            {t('dashboard.toAims', 'To AIMS')}
+                        </Typography>
+                        <ArrowForwardIcon fontSize="small" />
+                    </Stack>
+                </Stack>
+
+                <Stack gap={2}>
+                    <Box sx={{ p: 1.5, bgcolor: 'background.default', borderRadius: 2 }}>
+                        <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                            {t('aims.totalGateways')}
+                        </Typography>
+                        <Typography variant="h3" fontWeight={600} color="primary.main">
+                            {totalGateways}
+                        </Typography>
+                    </Box>
+
+                    {/* Gateway health bar */}
+                    <Stack gap={0.5}>
+                        <Stack direction="row" justifyContent="space-between" alignItems="center">
+                            <Typography variant="body2" color="text.secondary">
+                                {t('aims.online')} {onlineGateways}/{totalGateways}
+                            </Typography>
+                            <Typography variant="body2" fontWeight={600}>
+                                {gatewayHealthPercent}%
+                            </Typography>
+                        </Stack>
+                        <LinearProgress
+                            variant="determinate"
+                            value={gatewayHealthPercent}
+                            color="success"
+                            sx={{ height: 8, borderRadius: 4 }}
+                        />
+                    </Stack>
+
+                    <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 2 }}>
+                        <Box>
+                            <Typography variant="body2" color="text.secondary">
+                                {t('aims.online')}
+                            </Typography>
+                            <Typography variant="h5" fontWeight={500} color="success.main">
+                                {onlineGateways}
+                            </Typography>
+                        </Box>
+                        <Box>
+                            <Typography variant="body2" color="text.secondary">
+                                {t('aims.offline')}
+                            </Typography>
+                            <Typography variant="h5" fontWeight={500} color="error.main">
+                                {offlineGateways}
+                            </Typography>
+                        </Box>
+                        <Box>
+                            <Typography variant="body2" color="text.secondary">
+                                {t('aims.totalLabels')}
+                            </Typography>
+                            <Typography variant="h5" fontWeight={500}>
+                                {totalLabels}
+                            </Typography>
+                        </Box>
+                        <Box>
+                            <Typography variant="body2" color="text.secondary">
+                                {t('aims.onlineLabels')}
+                            </Typography>
+                            <Typography variant="h5" fontWeight={500} color="info.main">
+                                {onlineLabels}
+                            </Typography>
+                        </Box>
+                    </Box>
+                </Stack>
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/features/dashboard/components/index.ts
+++ b/src/features/dashboard/components/index.ts
@@ -3,6 +3,7 @@ export { DashboardStatusChip } from './DashboardStatusChip';
 export { DashboardSpacesCard } from './DashboardSpacesCard';
 export { DashboardConferenceCard } from './DashboardConferenceCard';
 export { DashboardPeopleCard } from './DashboardPeopleCard';
+export { DashboardAimsCard } from './DashboardAimsCard';
 export { DashboardSkeleton } from './DashboardSkeleton';
 export { QuickActionsPanel } from './QuickActionsPanel';
 export { MobileStatTile } from './MobileStatTile';

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -232,6 +232,7 @@
         "every": "Every",
         "toSpaces": "To Spaces",
         "toRooms": "To Rooms",
+        "toAims": "To AIMS",
         "toSpaceType": "To {{type}}",
         "toPeople": "To People",
         "managePeople": "Manage People",

--- a/src/locales/he/common.json
+++ b/src/locales/he/common.json
@@ -235,6 +235,7 @@
         "every": "כל",
         "toSpaces": "לחללים",
         "toRooms": "לחדרים",
+        "toAims": "לניהול AIMS",
         "toSpaceType": "ל-{{type}}",
         "toPeople": "לאנשים",
         "managePeople": "ניהול אנשים",


### PR DESCRIPTION
## Summary
- **Mobile responsive gateways**: GatewayList now shows card-based layout on mobile (< 960px) with tap-to-expand pattern, matching PeopleTable and ConferencePage conventions. Desktop still shows the table.
- **Dashboard AIMS card**: New `DashboardAimsCard` component shows gateway health (online/offline count + progress bar) and label stats. Conditionally rendered when `canAccessFeature('aims-management')` is true.
- **Product history fix**: Improved `extractResponseData()` in solumService to better handle SoluM's varied response shapes — adds debug logging, handles paginated `content` arrays, and strips metadata correctly. Client also handles `batchHistoryList` response field.

## Test plan
- [ ] Verify gateway list shows cards on mobile, table on desktop
- [ ] Verify mobile card tap expands to show IP, model, firmware, labels, and action buttons
- [ ] Verify Dashboard shows AIMS card when feature is enabled
- [ ] Verify Dashboard does NOT show AIMS card when feature is disabled
- [ ] Verify AIMS dashboard card navigates to /aims-management on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)