### PR TITLE
feat: client-side dithered label preview with ESL mockup frame

### DIFF
--- a/src/features/labels/domain/ditherUtils.ts
+++ b/src/features/labels/domain/ditherUtils.ts
@@ -1,0 +1,144 @@
+/**
+ * Client-side Floyd-Steinberg dithering for ESL label preview.
+ *
+ * Converts a full-color resized image into the label's native color palette
+ * (BINARY = black/white, TERNARY_RED = black/white/red) using error-diffusion
+ * dithering. This gives users an instant preview without an AIMS round-trip.
+ *
+ * Note: the actual label still receives server-side AIMS dithering on push —
+ * this is a client-only approximation for preview purposes.
+ */
+
+type RGB = [number, number, number];
+
+/** Color palettes matching AIMS label colorType values */
+const PALETTES: Record<string, RGB[]> = {
+    BINARY: [
+        [0, 0, 0],       // black
+        [255, 255, 255],  // white
+    ],
+    TERNARY_RED: [
+        [0, 0, 0],       // black
+        [255, 255, 255],  // white
+        [255, 0, 0],     // red
+    ],
+};
+
+/** Squared Euclidean distance between two RGB colors */
+function colorDistanceSq(a: RGB, b: RGB): number {
+    const dr = a[0] - b[0];
+    const dg = a[1] - b[1];
+    const db = a[2] - b[2];
+    return dr * dr + dg * dg + db * db;
+}
+
+/** Find the nearest palette color to a given pixel */
+function findNearest(pixel: RGB, palette: RGB[]): RGB {
+    let minDist = Infinity;
+    let nearest = palette[0];
+    for (const color of palette) {
+        const dist = colorDistanceSq(pixel, color);
+        if (dist < minDist) {
+            minDist = dist;
+            nearest = color;
+        }
+    }
+    return nearest;
+}
+
+/**
+ * Apply Floyd-Steinberg error-diffusion dithering to a canvas.
+ *
+ * Reads pixel data from the source canvas and returns a **new** canvas
+ * with the dithered result — the source is never mutated.
+ *
+ * @param sourceCanvas - Canvas with the resized full-color image
+ * @param colorType    - AIMS colorType string ("BINARY", "TERNARY_RED", …)
+ * @returns A new canvas containing the dithered image
+ */
+export function ditherImage(
+    sourceCanvas: HTMLCanvasElement,
+    colorType: string,
+): HTMLCanvasElement {
+    const width = sourceCanvas.width;
+    const height = sourceCanvas.height;
+    const ctx = sourceCanvas.getContext('2d')!;
+    const imageData = ctx.getImageData(0, 0, width, height);
+    const src = imageData.data; // Uint8ClampedArray [R,G,B,A, …]
+
+    // Use float array so error accumulation doesn't clamp prematurely
+    const pixels = new Float32Array(width * height * 3);
+    for (let i = 0; i < width * height; i++) {
+        pixels[i * 3] = src[i * 4];
+        pixels[i * 3 + 1] = src[i * 4 + 1];
+        pixels[i * 3 + 2] = src[i * 4 + 2];
+    }
+
+    const palette = PALETTES[colorType] ?? PALETTES.BINARY;
+
+    // Floyd-Steinberg error diffusion
+    for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++) {
+            const idx = (y * width + x) * 3;
+
+            const oldR = Math.max(0, Math.min(255, pixels[idx]));
+            const oldG = Math.max(0, Math.min(255, pixels[idx + 1]));
+            const oldB = Math.max(0, Math.min(255, pixels[idx + 2]));
+
+            const newPixel = findNearest([oldR, oldG, oldB], palette);
+
+            pixels[idx] = newPixel[0];
+            pixels[idx + 1] = newPixel[1];
+            pixels[idx + 2] = newPixel[2];
+
+            const errR = oldR - newPixel[0];
+            const errG = oldG - newPixel[1];
+            const errB = oldB - newPixel[2];
+
+            // Distribute error to neighbors: right, bottom-left, bottom, bottom-right
+            if (x + 1 < width) {
+                const i = idx + 3;
+                pixels[i] += errR * 7 / 16;
+                pixels[i + 1] += errG * 7 / 16;
+                pixels[i + 2] += errB * 7 / 16;
+            }
+            if (y + 1 < height) {
+                if (x - 1 >= 0) {
+                    const i = ((y + 1) * width + (x - 1)) * 3;
+                    pixels[i] += errR * 3 / 16;
+                    pixels[i + 1] += errG * 3 / 16;
+                    pixels[i + 2] += errB * 3 / 16;
+                }
+                {
+                    const i = ((y + 1) * width + x) * 3;
+                    pixels[i] += errR * 5 / 16;
+                    pixels[i + 1] += errG * 5 / 16;
+                    pixels[i + 2] += errB * 5 / 16;
+                }
+                if (x + 1 < width) {
+                    const i = ((y + 1) * width + (x + 1)) * 3;
+                    pixels[i] += errR * 1 / 16;
+                    pixels[i + 1] += errG * 1 / 16;
+                    pixels[i + 2] += errB * 1 / 16;
+                }
+            }
+        }
+    }
+
+    // Write result to a new canvas
+    const outCanvas = document.createElement('canvas');
+    outCanvas.width = width;
+    outCanvas.height = height;
+    const outCtx = outCanvas.getContext('2d')!;
+    const outData = outCtx.createImageData(width, height);
+
+    for (let i = 0; i < width * height; i++) {
+        outData.data[i * 4] = pixels[i * 3];
+        outData.data[i * 4 + 1] = pixels[i * 3 + 1];
+        outData.data[i * 4 + 2] = pixels[i * 3 + 2];
+        outData.data[i * 4 + 3] = 255; // fully opaque
+    }
+
+    outCtx.putImageData(outData, 0, 0);
+    return outCanvas;
+}

--- a/src/features/labels/presentation/AssignImageDialog.tsx
+++ b/src/features/labels/presentation/AssignImageDialog.tsx
@@ -27,8 +27,10 @@ import { useTranslation } from 'react-i18next';
 import { useAuthStore } from '@features/auth/infrastructure/authStore';
 import { labelsApi } from '@shared/infrastructure/services/labelsApi';
 import { loadImage, resizeImage, canvasToBase64 } from '../domain/imageUtils';
+import { ditherImage } from '../domain/ditherUtils';
 import type { LabelTypeInfo, FitMode } from '../domain/imageTypes';
 import { BarcodeScanner } from './BarcodeScanner';
+import { LabelMockup } from './LabelMockup';
 import { logger } from '@shared/infrastructure/services/logger';
 
 interface AssignImageDialogProps {
@@ -53,10 +55,7 @@ export function AssignImageDialog({ open, onClose, onSuccess, initialLabelCode }
     const [selectedFile, setSelectedFile] = useState<File | null>(null);
     const [fitMode, setFitMode] = useState<FitMode>('contain');
     const [resizedBase64, setResizedBase64] = useState<string | null>(null);
-
-    const [ditherPreview, setDitherPreview] = useState<string | null>(null);
-    const [isLoadingPreview, setIsLoadingPreview] = useState(false);
-    const [previewError, setPreviewError] = useState<string | null>(null);
+    const [ditheredBase64, setDitheredBase64] = useState<string | null>(null);
 
     const [isPushing, setIsPushing] = useState(false);
     const [pushError, setPushError] = useState<string | null>(null);
@@ -74,8 +73,7 @@ export function AssignImageDialog({ open, onClose, onSuccess, initialLabelCode }
             setTypeInfoError(null);
             setSelectedFile(null);
             setResizedBase64(null);
-            setDitherPreview(null);
-            setPreviewError(null);
+            setDitheredBase64(null);
             setPushError(null);
             setPushSuccess(false);
         }
@@ -89,7 +87,7 @@ export function AssignImageDialog({ open, onClose, onSuccess, initialLabelCode }
         setTypeInfoError(null);
         setTypeInfo(null);
         setResizedBase64(null);
-        setDitherPreview(null);
+        setDitheredBase64(null);
 
         try {
             const response = await labelsApi.getLabelTypeInfo(activeStoreId, code.trim());
@@ -102,13 +100,19 @@ export function AssignImageDialog({ open, onClose, onSuccess, initialLabelCode }
         }
     }, [activeStoreId]);
 
-    // Process image when file or fit mode changes
+    // Process image: resize then apply client-side dithering for instant preview
     const processImage = useCallback(async (file: File, mode: FitMode, info: LabelTypeInfo) => {
         try {
             const img = await loadImage(file);
             const canvas = resizeImage(img, info.displayWidth, info.displayHeight, mode);
             const base64 = canvasToBase64(canvas);
             setResizedBase64(base64);
+
+            // Client-side Floyd-Steinberg dithering for instant preview
+            const ditheredCanvas = ditherImage(canvas, info.colorType);
+            const ditheredB64 = canvasToBase64(ditheredCanvas);
+            setDitheredBase64(ditheredB64);
+
             return base64;
         } catch (error: any) {
             logger.error('AssignImageDialog', 'Failed to process image', { error: error.message });
@@ -116,41 +120,13 @@ export function AssignImageDialog({ open, onClose, onSuccess, initialLabelCode }
         }
     }, []);
 
-    // Fetch dither preview
-    const fetchDitherPreview = useCallback(async (base64: string, code: string) => {
-        if (!activeStoreId) return;
-
-        setIsLoadingPreview(true);
-        setPreviewError(null);
-        setDitherPreview(null);
-
-        try {
-            const response = await labelsApi.getDitherPreview(activeStoreId, code, base64);
-            // AIMS returns the dithered image in responseMessage or as a direct image field
-            const previewData = response.data?.responseMessage || response.data?.image || response.data;
-            if (typeof previewData === 'string') {
-                setDitherPreview(previewData);
-            } else {
-                setPreviewError(t('imageLabels.previewFailed', 'Could not generate preview'));
-            }
-        } catch (error: any) {
-            logger.error('AssignImageDialog', 'Failed to fetch dither preview', { error: error.message });
-            setPreviewError(error.response?.data?.error?.message || error.message);
-        } finally {
-            setIsLoadingPreview(false);
-        }
-    }, [activeStoreId, t]);
-
     // Handle file selection
     const handleFileSelect = async (file: File) => {
         setSelectedFile(file);
         setPushSuccess(false);
         setPushError(null);
         if (typeInfo) {
-            const base64 = await processImage(file, fitMode, typeInfo);
-            if (base64) {
-                await fetchDitherPreview(base64, labelCode);
-            }
+            await processImage(file, fitMode, typeInfo);
         }
     };
 
@@ -160,10 +136,7 @@ export function AssignImageDialog({ open, onClose, onSuccess, initialLabelCode }
         setFitMode(newMode);
         setPushSuccess(false);
         if (selectedFile && typeInfo) {
-            const base64 = await processImage(selectedFile, newMode, typeInfo);
-            if (base64) {
-                await fetchDitherPreview(base64, labelCode);
-            }
+            await processImage(selectedFile, newMode, typeInfo);
         }
     };
 
@@ -371,64 +344,19 @@ export function AssignImageDialog({ open, onClose, onSuccess, initialLabelCode }
                             </Box>
                         )}
 
-                        {/* Section 4: Dithered Preview */}
-                        {typeInfo && selectedFile && (
+                        {/* Section 4: Label Preview — client-side dithered mockup */}
+                        {typeInfo && ditheredBase64 && (
                             <Box>
                                 <Typography variant="subtitle2" gutterBottom>
-                                    {t('imageLabels.dialog.preview', 'Preview')}
+                                    {t('imageLabels.dialog.labelPreview', 'Label Preview')}
                                 </Typography>
-                                {isLoadingPreview ? (
-                                    <Box sx={{ display: 'flex', justifyContent: 'center', py: 3 }}>
-                                        <CircularProgress />
-                                    </Box>
-                                ) : previewError ? (
-                                    <Alert severity="warning" sx={{ mb: 1 }}>
-                                        {previewError}
-                                    </Alert>
-                                ) : null}
-
-                                {/* Show resized image (always available if file is selected) */}
-                                {resizedBase64 && (
-                                    <Stack spacing={1} alignItems="center">
-                                        {ditherPreview ? (
-                                            <Box>
-                                                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', textAlign: 'center', mb: 0.5 }}>
-                                                    {t('imageLabels.dialog.ditheredPreview', 'Dithered Preview (as it will appear on label)')}
-                                                </Typography>
-                                                <Box
-                                                    component="img"
-                                                    src={`data:image/png;base64,${ditherPreview}`}
-                                                    alt={t('imageLabels.dialog.altDitheredPreview', 'Dithered preview')}
-                                                    sx={{
-                                                        maxWidth: '100%',
-                                                        border: '2px solid',
-                                                        borderColor: 'divider',
-                                                        borderRadius: 1,
-                                                        bgcolor: 'background.paper',
-                                                    }}
-                                                />
-                                            </Box>
-                                        ) : (
-                                            <Box>
-                                                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', textAlign: 'center', mb: 0.5 }}>
-                                                    {t('imageLabels.dialog.resizedPreview', 'Resized Preview')}
-                                                </Typography>
-                                                <Box
-                                                    component="img"
-                                                    src={`data:image/png;base64,${resizedBase64}`}
-                                                    alt={t('imageLabels.dialog.altResizedPreview', 'Resized preview')}
-                                                    sx={{
-                                                        maxWidth: '100%',
-                                                        border: '2px solid',
-                                                        borderColor: 'divider',
-                                                        borderRadius: 1,
-                                                        bgcolor: 'background.paper',
-                                                    }}
-                                                />
-                                            </Box>
-                                        )}
-                                    </Stack>
-                                )}
+                                <LabelMockup
+                                    imageSrc={`data:image/png;base64,${ditheredBase64}`}
+                                    displayWidth={typeInfo.displayWidth}
+                                    displayHeight={typeInfo.displayHeight}
+                                    modelName={typeInfo.name}
+                                    colorType={typeInfo.colorType}
+                                />
                             </Box>
                         )}
 

--- a/src/features/labels/presentation/LabelMockup.tsx
+++ b/src/features/labels/presentation/LabelMockup.tsx
@@ -1,0 +1,99 @@
+import { Box, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+
+interface LabelMockupProps {
+    /** Base64 data URL for the dithered image (with data:image/png;base64, prefix) */
+    imageSrc: string;
+    /** Native display width in pixels */
+    displayWidth: number;
+    /** Native display height in pixels */
+    displayHeight: number;
+    /** Label model name (e.g. "Newton 2.9") */
+    modelName?: string;
+    /** AIMS colorType (e.g. "BINARY", "TERNARY_RED") */
+    colorType?: string;
+}
+
+/**
+ * Realistic ESL (Electronic Shelf Label) mockup that renders the dithered
+ * preview image inside a visual frame resembling the physical label housing.
+ */
+export function LabelMockup({
+    imageSrc,
+    displayWidth,
+    displayHeight,
+    modelName,
+    colorType,
+}: LabelMockupProps) {
+    const { t } = useTranslation();
+
+    return (
+        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1.5 }}>
+            {/* Label housing — dark plastic casing */}
+            <Box
+                sx={{
+                    p: '10px',
+                    bgcolor: '#2a2a2a',
+                    borderRadius: '10px',
+                    border: '1px solid rgba(255,255,255,0.08)',
+                    boxShadow:
+                        '0 6px 20px rgba(0,0,0,0.3), 0 1px 3px rgba(0,0,0,0.2), inset 0 1px 0 rgba(255,255,255,0.06)',
+                    maxWidth: '100%',
+                    width: 'fit-content',
+                }}
+            >
+                {/* Inner bezel — recessed display area */}
+                <Box
+                    sx={{
+                        p: '2px',
+                        bgcolor: '#1a1a1a',
+                        borderRadius: '4px',
+                        border: '1px solid #383838',
+                    }}
+                >
+                    {/* E-ink display */}
+                    <Box
+                        component="img"
+                        src={imageSrc}
+                        alt={t('imageLabels.dialog.altLabelPreview', 'Label preview mockup')}
+                        sx={{
+                            display: 'block',
+                            width: Math.min(displayWidth, 400),
+                            aspectRatio: `${displayWidth} / ${displayHeight}`,
+                            maxWidth: '100%',
+                            height: 'auto',
+                            borderRadius: '2px',
+                            imageRendering: 'pixelated',
+                        }}
+                    />
+                </Box>
+
+                {/* LED indicator */}
+                <Box
+                    sx={{
+                        display: 'flex',
+                        justifyContent: 'center',
+                        mt: '6px',
+                    }}
+                >
+                    <Box
+                        sx={{
+                            width: 5,
+                            height: 5,
+                            borderRadius: '50%',
+                            bgcolor: '#3a3a3a',
+                            border: '1px solid #4a4a4a',
+                        }}
+                    />
+                </Box>
+            </Box>
+
+            {/* Label info */}
+            <Typography variant="caption" color="text.secondary" sx={{ textAlign: 'center' }}>
+                {[modelName, `${displayWidth}×${displayHeight}`, colorType]
+                    .filter(Boolean)
+                    .join(' — ')}
+            </Typography>
+        </Box>
+    );
+}

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1499,7 +1499,9 @@
             "scanLabel": "Scan Label Code",
             "acceptedFormats": "PNG, JPEG, BMP",
             "altDitheredPreview": "Dithered preview",
-            "altResizedPreview": "Resized preview"
+            "altResizedPreview": "Resized preview",
+            "labelPreview": "Label Preview",
+            "altLabelPreview": "Label preview mockup"
         }
     }
 }

--- a/src/locales/he/common.json
+++ b/src/locales/he/common.json
@@ -1514,7 +1514,9 @@
             "scanLabel": "סרוק קוד תגית",
             "acceptedFormats": "PNG, JPEG, BMP",
             "altDitheredPreview": "תצוגה מקדימה מעובדת",
-            "altResizedPreview": "תצוגה מקדימה מוקטנת"
+            "altResizedPreview": "תצוגה מקדימה מוקטנת",
+            "labelPreview": "תצוגה מקדימה של תגית",
+            "altLabelPreview": "דגם תצוגה מקדימה של תגית"
         }
     }
 }


### PR DESCRIPTION
Replace the AIMS server round-trip dither preview with instant
client-side Floyd-Steinberg error-diffusion dithering. Supports
BINARY (black/white) and TERNARY_RED (black/white/red) palettes.

Add a LabelMockup component that renders the dithered preview
inside a realistic ESL label housing frame (dark bezel, LED
indicator, model info).

- New: ditherUtils.ts — Floyd-Steinberg dithering engine
- New: LabelMockup.tsx — ESL label frame visualization
- Updated: AssignImageDialog — uses instant local preview
- Updated: EN/HE translations with new label preview keys

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

https://claude.ai/code/session_01ATYXjyJj1edtZasrtanhx4