### PR TITLE
fix: AssignImageDialog root cause + UX improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **AssignImageDialog crash on zero-dimension labels** — `getImageData` threw when AIMS returned `displayWidth` or `displayHeight` of 0; added dimension validation in `loadImage`, `resizeImage`, and `ditherImage`; added user-visible error alert in the dialog
+- **AssignImageDialog crash on zero-dimension labels (root cause)** — `solumService.fetchLabelTypeInfo()` returned raw AIMS envelope without `extractResponseData()`, so `displayWidth`/`displayHeight` were `undefined`; client guards also hardened (`!targetW || !targetH` catches `undefined`/`NaN`)
+- **AssignImageDialog empty chips** — label info chips (dimensions, color type) were blank because the AIMS envelope fields were returned instead of actual data
+
+### Changed
+- **AssignImageDialog UX improvements** — disable autofocus (was hiding camera/manual tabs on mobile); 90° rotation (was 180°); loading spinner during image processing; `dir="ltr"` on fit-mode tabs for correct RTL display
 
 ---
 

--- a/docs/wiki/Chapter-5-—-Integration-&-Synchronization.md
+++ b/docs/wiki/Chapter-5-—-Integration-&-Synchronization.md
@@ -155,7 +155,7 @@ The image push flow processes user-uploaded images through a client-side canvas 
 User selects image file
   → loadImage(file)          — validate non-zero naturalWidth/Height
   → resizeImage(img, w, h)   — validate target dimensions > 0, apply fit mode
-  → rotateCanvas180(canvas)  — optional 180° flip
+  → rotateCanvas(canvas, steps) — optional 90° rotation (steps=1–3)
   → canvasToBase64(canvas)   — PNG base64 (without data URI prefix)
   → ditherImage(canvas, colorType) — Floyd-Steinberg to label palette (bw/bwr/bwry/6c)
   → LabelMockup preview      — instant client-side preview
@@ -166,7 +166,7 @@ Key utilities in `labels/domain/`:
 
 | File | Purpose |
 |------|---------|
-| `imageUtils.ts` | `loadImage`, `resizeImage` (contain/cover/fill), `rotateCanvas180`, `canvasToBase64` |
+| `imageUtils.ts` | `loadImage`, `resizeImage` (contain/cover/fill), `rotateCanvas` (90° steps), `canvasToBase64` |
 | `ditherUtils.ts` | `ditherImage` — Floyd-Steinberg error-diffusion dithering to label color palette |
 | `imageTypes.ts` | `LabelTypeInfo` (displayWidth, displayHeight, colorType, color), `FitMode` |
 

--- a/server/src/shared/infrastructure/services/solumService.ts
+++ b/server/src/shared/infrastructure/services/solumService.ts
@@ -562,7 +562,7 @@ export class SolumService {
                 const response = await this.client.get(url, {
                     headers: { 'Authorization': `Bearer ${token}` }
                 });
-                return response.data as AimsLabelTypeInfo;
+                return this.extractResponseData(response.data, 'fetchLabelTypeInfo') as AimsLabelTypeInfo;
             } catch (error: any) {
                 throw new Error(`Fetch label type info failed: ${error.message}`);
             }

--- a/src/features/labels/domain/ditherUtils.ts
+++ b/src/features/labels/domain/ditherUtils.ts
@@ -109,7 +109,7 @@ export function ditherImage(
     const width = sourceCanvas.width;
     const height = sourceCanvas.height;
 
-    if (width === 0 || height === 0) {
+    if (!width || !height) {
         throw new Error(`Cannot dither canvas with dimensions ${width}×${height}`);
     }
 

--- a/src/features/labels/domain/imageUtils.ts
+++ b/src/features/labels/domain/imageUtils.ts
@@ -42,8 +42,8 @@ export function resizeImage(
     targetH: number,
     fitMode: FitMode,
 ): HTMLCanvasElement {
-    if (targetW <= 0 || targetH <= 0) {
-        throw new Error(`Invalid target dimensions: ${targetW}×${targetH}`);
+    if (!targetW || !targetH || targetW <= 0 || targetH <= 0) {
+        throw new Error(`Invalid target dimensions: ${targetW ?? 'undefined'}×${targetH ?? 'undefined'}`);
     }
 
     const canvas = document.createElement('canvas');
@@ -100,16 +100,22 @@ export function resizeImage(
 }
 
 /**
- * Rotate a canvas 180° (flip upside-down). Returns a new canvas.
+ * Rotate a canvas by the given number of 90° clockwise steps.
+ * steps=1 → 90°, steps=2 → 180°, steps=3 → 270°.
+ * Returns a new canvas (source is not mutated).
  */
-export function rotateCanvas180(source: HTMLCanvasElement): HTMLCanvasElement {
+export function rotateCanvas(source: HTMLCanvasElement, steps: number): HTMLCanvasElement {
+    const s = ((steps % 4) + 4) % 4; // normalise to 0-3
+    if (s === 0) return source;
+
+    const swap = s === 1 || s === 3;
     const canvas = document.createElement('canvas');
-    canvas.width = source.width;
-    canvas.height = source.height;
+    canvas.width = swap ? source.height : source.width;
+    canvas.height = swap ? source.width : source.height;
     const ctx = canvas.getContext('2d')!;
-    ctx.translate(source.width, source.height);
-    ctx.rotate(Math.PI);
-    ctx.drawImage(source, 0, 0);
+    ctx.translate(canvas.width / 2, canvas.height / 2);
+    ctx.rotate((s * Math.PI) / 2);
+    ctx.drawImage(source, -source.width / 2, -source.height / 2);
     return canvas;
 }
 

--- a/src/features/labels/presentation/AssignImageDialog.tsx
+++ b/src/features/labels/presentation/AssignImageDialog.tsx
@@ -22,12 +22,12 @@ import {
     Close as CloseIcon,
     QrCodeScanner as ScannerIcon,
     CloudUpload as UploadIcon,
-    Flip as FlipIcon,
+    RotateRight as RotateIcon,
 } from '@mui/icons-material';
 import { useTranslation } from 'react-i18next';
 import { useAuthStore } from '@features/auth/infrastructure/authStore';
 import { labelsApi } from '@shared/infrastructure/services/labelsApi';
-import { loadImage, resizeImage, rotateCanvas180, canvasToBase64 } from '../domain/imageUtils';
+import { loadImage, resizeImage, rotateCanvas, canvasToBase64 } from '../domain/imageUtils';
 import { ditherImage } from '../domain/ditherUtils';
 import type { LabelTypeInfo, FitMode } from '../domain/imageTypes';
 import { BarcodeScanner } from './BarcodeScanner';
@@ -55,10 +55,11 @@ export function AssignImageDialog({ open, onClose, onSuccess, initialLabelCode }
 
     const [selectedFile, setSelectedFile] = useState<File | null>(null);
     const [fitMode, setFitMode] = useState<FitMode>('contain');
-    const [flipped, setFlipped] = useState(false);
+    const [rotation, setRotation] = useState(0); // 0-3 for 0°/90°/180°/270°
     const [resizedBase64, setResizedBase64] = useState<string | null>(null);
     const [ditheredBase64, setDitheredBase64] = useState<string | null>(null);
     const [imageError, setImageError] = useState<string | null>(null);
+    const [isProcessing, setIsProcessing] = useState(false);
 
     const [isPushing, setIsPushing] = useState(false);
     const [pushError, setPushError] = useState<string | null>(null);
@@ -75,7 +76,7 @@ export function AssignImageDialog({ open, onClose, onSuccess, initialLabelCode }
             setTypeInfo(null);
             setTypeInfoError(null);
             setSelectedFile(null);
-            setFlipped(false);
+            setRotation(0);
             setResizedBase64(null);
             setDitheredBase64(null);
             setImageError(null);
@@ -105,14 +106,15 @@ export function AssignImageDialog({ open, onClose, onSuccess, initialLabelCode }
         }
     }, [activeStoreId]);
 
-    // Process image: resize, optionally flip, then apply client-side dithering
-    const processImage = useCallback(async (file: File, mode: FitMode, info: LabelTypeInfo, flip: boolean) => {
+    // Process image: resize, optionally rotate, then apply client-side dithering
+    const processImage = useCallback(async (file: File, mode: FitMode, info: LabelTypeInfo, rotationSteps: number) => {
         setImageError(null);
+        setIsProcessing(true);
         try {
             const img = await loadImage(file);
             let canvas = resizeImage(img, info.displayWidth, info.displayHeight, mode);
-            if (flip) {
-                canvas = rotateCanvas180(canvas);
+            if (rotationSteps > 0) {
+                canvas = rotateCanvas(canvas, rotationSteps);
             }
             const base64 = canvasToBase64(canvas);
             setResizedBase64(base64);
@@ -129,6 +131,8 @@ export function AssignImageDialog({ open, onClose, onSuccess, initialLabelCode }
             setDitheredBase64(null);
             setImageError(error.message);
             return null;
+        } finally {
+            setIsProcessing(false);
         }
     }, []);
 
@@ -138,7 +142,7 @@ export function AssignImageDialog({ open, onClose, onSuccess, initialLabelCode }
         setPushSuccess(false);
         setPushError(null);
         if (typeInfo) {
-            await processImage(file, fitMode, typeInfo, flipped);
+            await processImage(file, fitMode, typeInfo, rotation);
         }
     };
 
@@ -148,17 +152,17 @@ export function AssignImageDialog({ open, onClose, onSuccess, initialLabelCode }
         setFitMode(newMode);
         setPushSuccess(false);
         if (selectedFile && typeInfo) {
-            await processImage(selectedFile, newMode, typeInfo, flipped);
+            await processImage(selectedFile, newMode, typeInfo, rotation);
         }
     };
 
-    // Handle flip toggle
-    const handleFlipToggle = async () => {
-        const newFlipped = !flipped;
-        setFlipped(newFlipped);
+    // Handle rotation (90° clockwise each press)
+    const handleRotate = async () => {
+        const newRotation = (rotation + 1) % 4;
+        setRotation(newRotation);
         setPushSuccess(false);
         if (selectedFile && typeInfo) {
-            await processImage(selectedFile, fitMode, typeInfo, newFlipped);
+            await processImage(selectedFile, fitMode, typeInfo, newRotation);
         }
     };
 
@@ -219,9 +223,18 @@ export function AssignImageDialog({ open, onClose, onSuccess, initialLabelCode }
         }
     };
 
+    const rotationLabel = rotation > 0 ? `${rotation * 90}°` : '';
+
     return (
         <>
-            <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth fullScreen={isMobile}>
+            <Dialog
+                open={open}
+                onClose={onClose}
+                maxWidth="sm"
+                fullWidth
+                fullScreen={isMobile}
+                disableAutoFocus
+            >
                 <DialogTitle>
                     <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                         <Typography variant="h6">
@@ -271,22 +284,28 @@ export function AssignImageDialog({ open, onClose, onSuccess, initialLabelCode }
 
                             {typeInfo && (
                                 <Stack direction="row" spacing={1} sx={{ mt: 1 }} flexWrap="wrap" useFlexGap>
-                                    <Chip
-                                        label={`${typeInfo.displayWidth}×${typeInfo.displayHeight} px`}
-                                        size="small"
-                                        color="primary"
-                                        variant="outlined"
-                                    />
-                                    <Chip
-                                        label={typeInfo.colorType}
-                                        size="small"
-                                        variant="outlined"
-                                    />
-                                    <Chip
-                                        label={typeInfo.name}
-                                        size="small"
-                                        variant="outlined"
-                                    />
+                                    {typeInfo.displayWidth > 0 && typeInfo.displayHeight > 0 && (
+                                        <Chip
+                                            label={`${typeInfo.displayWidth}×${typeInfo.displayHeight} px`}
+                                            size="small"
+                                            color="primary"
+                                            variant="outlined"
+                                        />
+                                    )}
+                                    {typeInfo.colorType && (
+                                        <Chip
+                                            label={typeInfo.colorType}
+                                            size="small"
+                                            variant="outlined"
+                                        />
+                                    )}
+                                    {typeInfo.name && (
+                                        <Chip
+                                            label={typeInfo.name}
+                                            size="small"
+                                            variant="outlined"
+                                        />
+                                    )}
                                     {typeInfo.nfc && (
                                         <Chip label="NFC" size="small" color="info" variant="outlined" />
                                     )}
@@ -312,9 +331,24 @@ export function AssignImageDialog({ open, onClose, onSuccess, initialLabelCode }
                                         textAlign: 'center',
                                         cursor: 'pointer',
                                         bgcolor: 'action.hover',
+                                        position: 'relative',
                                         '&:hover': { borderColor: 'primary.main' },
                                     }}
                                 >
+                                    {isProcessing && (
+                                        <Box sx={{
+                                            position: 'absolute',
+                                            inset: 0,
+                                            display: 'flex',
+                                            alignItems: 'center',
+                                            justifyContent: 'center',
+                                            bgcolor: 'rgba(255,255,255,0.7)',
+                                            borderRadius: 2,
+                                            zIndex: 1,
+                                        }}>
+                                            <CircularProgress />
+                                        </Box>
+                                    )}
                                     <UploadIcon sx={{ fontSize: 40, color: 'text.secondary', mb: 1 }} />
                                     <Typography variant="body2" color="text.secondary">
                                         {selectedFile
@@ -341,42 +375,47 @@ export function AssignImageDialog({ open, onClose, onSuccess, initialLabelCode }
                             </Alert>
                         )}
 
-                        {/* Section 3: Fit Mode & Flip */}
+                        {/* Section 3: Fit Mode & Rotate */}
                         {typeInfo && selectedFile && (
                             <Box>
                                 <Typography variant="subtitle2" gutterBottom>
                                     {t('imageLabels.dialog.fitMode', 'Fit Mode')}
                                 </Typography>
-                                <Stack direction="row" spacing={1} alignItems="center">
+                                <Box sx={{ display: 'flex', justifyContent: 'center', mb: 1 }}>
                                     <ToggleButtonGroup
                                         value={fitMode}
                                         exclusive
                                         onChange={handleFitModeChange}
                                         size="small"
-                                        sx={{ flex: 1 }}
+                                        dir="ltr"
+                                        aria-label={t('imageLabels.dialog.ariaFitMode', 'image fit mode')}
                                     >
-                                        <ToggleButton value="contain">
+                                        <ToggleButton value="contain" sx={{ gap: 0.5 }}>
                                             {t('imageLabels.dialog.fitContain', 'Contain')}
                                         </ToggleButton>
-                                        <ToggleButton value="cover">
+                                        <ToggleButton value="cover" sx={{ gap: 0.5 }}>
                                             {t('imageLabels.dialog.fitCover', 'Cover')}
                                         </ToggleButton>
-                                        <ToggleButton value="fill">
+                                        <ToggleButton value="fill" sx={{ gap: 0.5 }}>
                                             {t('imageLabels.dialog.fitFill', 'Fill')}
                                         </ToggleButton>
                                     </ToggleButtonGroup>
-                                    <ToggleButton
-                                        value="flip"
-                                        selected={flipped}
-                                        onChange={handleFlipToggle}
+                                    <IconButton
+                                        onClick={handleRotate}
                                         size="small"
-                                        title={t('imageLabels.dialog.flipTooltip', 'Rotate 180°')}
+                                        color={rotation > 0 ? 'primary' : 'default'}
+                                        title={t('imageLabels.dialog.rotateTooltip', 'Rotate 90°')}
+                                        sx={{ ml: 1 }}
                                     >
-                                        <FlipIcon sx={{ mr: 0.5 }} fontSize="small" />
-                                        {t('imageLabels.dialog.flip', 'Flip')}
-                                    </ToggleButton>
-                                </Stack>
-                                <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
+                                        <RotateIcon />
+                                        {rotationLabel && (
+                                            <Typography variant="caption" sx={{ fontSize: '0.65rem', ml: 0.25 }}>
+                                                {rotationLabel}
+                                            </Typography>
+                                        )}
+                                    </IconButton>
+                                </Box>
+                                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', textAlign: 'center' }}>
                                     {fitMode === 'contain' && t('imageLabels.dialog.fitContainHelp', 'Fits image within label, may add white bars')}
                                     {fitMode === 'cover' && t('imageLabels.dialog.fitCoverHelp', 'Fills label completely, may crop image')}
                                     {fitMode === 'fill' && t('imageLabels.dialog.fitFillHelp', 'Stretches image to fill label exactly')}

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1503,8 +1503,8 @@
             "altResizedPreview": "Resized preview",
             "labelPreview": "Label Preview",
             "altLabelPreview": "Label preview mockup",
-            "flip": "Flip",
-            "flipTooltip": "Rotate 180°"
+            "rotateTooltip": "Rotate 90°",
+            "ariaFitMode": "image fit mode"
         }
     }
 }

--- a/src/locales/he/common.json
+++ b/src/locales/he/common.json
@@ -1518,8 +1518,8 @@
             "altResizedPreview": "תצוגה מקדימה מוקטנת",
             "labelPreview": "תצוגה מקדימה של תגית",
             "altLabelPreview": "דגם תצוגה מקדימה של תגית",
-            "flip": "הפוך",
-            "flipTooltip": "סובב 180°"
+            "rotateTooltip": "סובב 90°",
+            "ariaFitMode": "מצב התאמת תמונה"
         }
     }
 }


### PR DESCRIPTION
## Summary
- **Root cause fix**: `solumService.fetchLabelTypeInfo()` now uses `extractResponseData()` to strip AIMS envelope — `displayWidth`/`displayHeight` were `undefined`
- **Client guards hardened**: `!targetW || !targetH` catches `undefined`/`NaN` (JS: `undefined <= 0` is `false`)
- **UX**: disable autofocus on mobile, 90° rotation (was 180°), loading spinner, RTL-safe fit-mode tabs, guarded label info chips

Closes #96

## Test plan
- [ ] Open AssignImageDialog on a label with valid AIMS type info — chips show dimensions and color type
- [ ] Upload image — loading spinner appears during processing, preview renders correctly
- [ ] Rotate button increments 90° each click (4 clicks = full circle)
- [ ] Switch to Hebrew — fit-mode tabs (contain/cover/fill) display left-to-right
- [ ] Open dialog on mobile — keyboard does not auto-appear, camera/manual tabs visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)