### PR TITLE
fix: correct AIMS URL path for fetchLabelTypeInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **AssignImageDialog crash on zero-dimension labels (root cause)** — `solumService.fetchLabelTypeInfo()` returned raw AIMS envelope without `extractResponseData()`, so `displayWidth`/`displayHeight` were `undefined`; client guards also hardened (`!targetW || !targetH` catches `undefined`/`NaN`)
 - **AssignImageDialog empty chips** — label info chips (dimensions, color type) were blank because the AIMS envelope fields were returned instead of actual data
+- **AIMS label type info wrong URL** — `fetchLabelTypeInfo` used `/api/v2/...` instead of `/common/api/v2/...`, hitting wrong AIMS endpoint and returning incorrect data
 
 ### Changed
 - **AssignImageDialog UX improvements** — disable autofocus (was hiding camera/manual tabs on mobile); 90° rotation (was 180°); loading spinner during image processing; `dir="ltr"` on fit-mode tabs for correct RTL display

--- a/server/src/shared/infrastructure/services/solumService.ts
+++ b/server/src/shared/infrastructure/services/solumService.ts
@@ -555,7 +555,7 @@ export class SolumService {
      * Fetch label type/hardware info (dimensions, color type, etc.)
      */
     async fetchLabelTypeInfo(config: SolumConfig, token: string, labelCode: string): Promise<AimsLabelTypeInfo> {
-        const url = this.buildUrl(config, `/api/v2/common/labels/type/info?labelCode=${encodeURIComponent(labelCode)}`);
+        const url = this.buildUrl(config, `/common/api/v2/common/labels/type/info?labelCode=${encodeURIComponent(labelCode)}`);
 
         return this.withRetry('fetchLabelTypeInfo', async () => {
             try {

--- a/solumapi.yaml
+++ b/solumapi.yaml
@@ -2159,7 +2159,7 @@ paths:
 
 #################### GET LABEL TYPE ####################
 
-  /api/v2/common/labels/type/info:
+  /common/api/v2/common/labels/type/info:
 
     get:
       tags:


### PR DESCRIPTION
## Summary
- `fetchLabelTypeInfo` used `/api/v2/common/labels/type/info` but should use `/common/api/v2/common/labels/type/info` (like all other AIMS endpoints)
- The wrong URL hit an incorrect AIMS endpoint, returning 25KB of wrong data instead of label properties (`displayWidth`, `displayHeight`, `colorType`)
- This was the actual root cause of the AssignImageDialog `getImageData` crash

Closes #98

## Test plan
- [ ] Open AssignImageDialog, scan/enter a label code — chips should show correct dimensions, color type, and model name
- [ ] Upload an image — preview renders correctly without canvas errors
- [ ] Verify server logs show `fetchLabelTypeInfo` returning small response (~200 bytes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)