### PR TITLE
fix: user dialog crash on open + wiki RBAC update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Permission test mock data** — tests used old enum-based role names (`COMPANY_ADMIN`, `STORE_ADMIN`) instead of current `roleId` values (`role-admin`, `role-manager`, etc.), causing 13 false failures
 - **SphereLoader crash in test environment** — `i18n.dir()` called without null check, failing in environments where `dir` is not mocked; now uses optional chaining
 - **LoadingFallback/RouteLoadingFallback tests outdated** — tests expected old skeleton/CircularProgress implementation but components now use SphereLoader; tests updated to match current behavior
+- **User dialog crash on open** — `canEditAppRole` useMemo crashed on `c.company.id` when user prop had flat company shape (from list API) instead of nested shape (from detail API); now handles both shapes
 
 ### Changed
 - **Chip and button padding** — added inline padding to chips (4px) and primary contained buttons (20px) for better visual spacing

--- a/docs/wiki/Chapter-7-—-Security,-Auth-&-Access-Control.md
+++ b/docs/wiki/Chapter-7-—-Security,-Auth-&-Access-Control.md
@@ -112,44 +112,57 @@ sequenceDiagram
 
 ### 7.4 Role-Based Access Control (RBAC)
 
-Store-level roles are now **database-backed** via the `roles` table, replacing the previous hardcoded `StoreRole` enum. This allows platform and company admins to create custom roles with granular permissions.
+The system uses a **three-tier role architecture**: app roles (global), company roles (DB-backed), and store roles (DB-backed). Both company and store roles reference the same `roles` table, replacing the previous hardcoded enums.
 
 ```mermaid
 graph TB
-    subgraph "Global Level"
+    subgraph "App Level (GlobalRole)"
         PA[PLATFORM_ADMIN<br/>Full system access]
+        AV[APP_VIEWER<br/>Read-only, all CUD disabled]
+        RU[USER (null)<br/>Regular authenticated user]
     end
 
-    subgraph "Company Level (CompanyRole)"
-        SU[SUPER_USER<br/>Full access, no restrictions]
-        CA[COMPANY_ADMIN<br/>Manage settings, users, stores]
-        CV[VIEWER<br/>Read-only access]
+    subgraph "Company Level (DB-backed roleId)"
+        CA[role-admin<br/>Manage settings, users, stores]
+        CM[role-manager<br/>CRUD + sync, no user mgmt]
+        CE[role-employee<br/>Read + update only]
+        CV[role-viewer<br/>Read-only access]
     end
 
-    subgraph "Store Level (DB-backed roles)"
-        SA[Admin<br/>Full store operations]
-        SM[Manager<br/>CRUD + sync, no user mgmt]
-        SE[Employee<br/>Read + update only]
-        SV[Viewer<br/>Read only]
+    subgraph "Store Level (DB-backed roleId)"
+        SA[role-admin<br/>Full store operations]
+        SM[role-manager<br/>CRUD + sync, no user mgmt]
+        SE[role-employee<br/>Read + update only]
+        SV[role-viewer<br/>Read only]
         CR[Custom Roles<br/>Admin-defined permissions]
     end
 
-    PA --> SU
-    SU --> CA
-    CA --> CV
+    PA --> CA
+    CA --> CM
+    CM --> CE
+    CE --> CV
     SA --> SM
     SM --> SE
     SE --> SV
 
     style PA fill:#e74c3c,color:#fff
-    style SU fill:#c0392b,color:#fff
+    style AV fill:#95a5a6,color:#fff
+    style RU fill:#bdc3c7,color:#333
     style CA fill:#e67e22,color:#fff
+    style CM fill:#f39c12,color:#fff
+    style CE fill:#3498db,color:#fff
+    style CV fill:#95a5a6,color:#fff
     style SA fill:#27ae60,color:#fff
     style SM fill:#2ecc71,color:#fff
     style SE fill:#3498db,color:#fff
     style SV fill:#95a5a6,color:#fff
     style CR fill:#9b59b6,color:#fff
 ```
+
+**App Role Elevation:**
+- Only **PLATFORM_ADMIN** users can view and change another user's app role.
+- App roles can be changed via the inline radio selector in the user dialog (edit mode).
+- Enforced on both client (permission helpers gate UI visibility) and server (`elevate()` rejects non-platform-admin callers).
 
 **Role Scopes:**
 - **SYSTEM** roles are built-in defaults (Admin, Manager, Employee, Viewer) — available to all companies, cannot be deleted.

--- a/src/features/settings/presentation/userDialog/useUserDialogState.ts
+++ b/src/features/settings/presentation/userDialog/useUserDialogState.ts
@@ -284,7 +284,10 @@ export function useUserDialogState({ open, onSave, user, profileMode }: Params) 
         return canElevateUser(currentUser, {
             id: userData.id,
             globalRole: userData.globalRole,
-            companies: userData.companies?.map(c => ({ id: c.company.id })),
+            companies: userData.companies?.map(c => ({
+                // Handle both nested (UserData) and flat (User from list) shapes
+                id: (c as any).company?.id ?? (c as any).id,
+            })),
         });
     }, [currentUser, userData]);
 


### PR DESCRIPTION
## Summary

- **Fix production crash** — user dialog crashed on open with `TypeError: Cannot read properties of undefined (reading 'id')` because `canEditAppRole` useMemo accessed `c.company.id` but the user list API returns flat company objects (`{id, name}`) while the detail API returns nested (`{company: {id, name}}`). Now handles both shapes.
- **Update wiki RBAC docs** — Chapter 7.4 diagram updated to show the three-tier role architecture (app roles / company roles / store roles) with DB-backed roleIds, replacing the outdated CompanyRole enum diagram. Documents app role elevation restriction to platform admins.

## Test plan

- [x] Client build passes
- [ ] Open user dialog in production — no crash
- [ ] Wiki publishes correctly via GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)