### PR TITLE
fix: roles audit remediation — security, permissions, scope fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **App role editing in user dialog** — platform admins can set/change a user's app role (Platform Admin, App Viewer, Regular User) directly from the user dialog via inline radio cards
 - **Roles audit remediation plan** — comprehensive 4-phase plan documenting 16 security, functional, and polish improvements for the roles system (`docs/plans/2026-03-01-roles-audit-remediation.md`)
 
+### Security
+- **Roles CRUD endpoints protected** — POST/PATCH/DELETE on `/api/v1/roles` now require `PLATFORM_ADMIN`; GET requires `settings:view` permission
+- **Elevate endpoint defense-in-depth** — `POST /users/:id/elevate` now has `requireGlobalRole('PLATFORM_ADMIN')` middleware guard
+- **Bulk user operations protected** — bulk deactivate/activate/role endpoints now require `users:edit` permission
+- **Settings write endpoints protected** — PUT on company settings, field-mappings, and article-format now require `settings:update` permission
+- **allStoresAccess privilege escalation fixed** — company managers with `allStoresAccess` no longer silently get admin permissions on expanded stores; uses actual company roleId instead of hardcoded `role-admin`
+- **requirePermission fallback fixed** — allStoresAccess companies now use their actual roleId for permission checks instead of hardcoded `role-admin`
+- **RoleId validation on user creation/assignment** — invalid roleId values now return 400 instead of opaque Prisma FK errors
+- **Action alias normalization** — `requirePermission()` now normalizes legacy `read`→`view` and `update`→`edit` aliases to prevent permission bypass from mismatched action names
+- **Role permissions cache invalidation** — roles service now invalidates permission cache on update/delete, preventing stale permissions being served for up to 60 seconds
+
 ### Fixed
 - **AIMS dither preview not working** — `solumService.fetchDitherPreview()` returned raw AIMS envelope without `extractResponseData()`, so the client received `{responseCode, responseMessage}` instead of image data; client now robustly extracts the image from multiple possible response shapes
 - **BarcodeScanner autofocus on mobile** — removed autofocus from scanner/manual inputs that triggered the virtual keyboard and hid the camera/scanner/manual tabs on mobile devices
@@ -28,8 +39,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **SphereLoader crash in test environment** — `i18n.dir()` called without null check, failing in environments where `dir` is not mocked; now uses optional chaining
 - **LoadingFallback/RouteLoadingFallback tests outdated** — tests expected old skeleton/CircularProgress implementation but components now use SphereLoader; tests updated to match current behavior
 - **User dialog crash on open** — `canEditAppRole` useMemo crashed on `c.company.id` when user prop had flat company shape (from list API) instead of nested shape (from detail API); now handles both shapes
+- **User table role chip broken** — role chip in user list accessed non-existent `.role` field instead of `.roleId`, causing company admin detection to always fail; refactored to use `getUserRoleDisplay()` helper with proper `roleId`-based detection
+- **User profile role label single-company** — `getRoleLabel()` only showed first company's role; now scans all company/store assignments and returns the highest-priority role
 
 ### Changed
+- **Dead `authorize()` middleware removed** — unused role-name-based middleware removed from auth module; replaced by `requirePermission()` and `requireGlobalRole()`
+- **APP_VIEWER self-service patterns extracted** — hardcoded URL exceptions moved to `APP_VIEWER_SELF_SERVICE_PATTERNS` constant for maintainability
+- **Audit logging for role changes** — all role mutations (elevate, assignToStore, assignToCompany, updateUserStore, updateUserCompany) now log structured audit entries via `appLogger`
+- **User table role scope indicators** — role chips now show "App Admin", "Company Admin", etc. with scope-aware labels instead of ambiguous "Admin"
 - **Chip and button padding** — added inline padding to chips (4px) and primary contained buttons (20px) for better visual spacing
 
 ### Changed

--- a/docs/wiki/Chapter-7-—-Security,-Auth-&-Access-Control.md
+++ b/docs/wiki/Chapter-7-—-Security,-Auth-&-Access-Control.md
@@ -252,7 +252,11 @@ graph LR
     GLOBAL --> HANDLER
 ```
 
-The auth middleware uses a 60-second in-memory cache (max 500 entries) to reduce database queries. The cache is invalidated when user roles or store assignments change.
+The auth middleware uses a 60-second in-memory cache (max 500 entries) to reduce database queries. The cache is invalidated when user roles or store assignments change via `invalidateUserCache(userId)`. Similarly, role permission lookups are cached for 60 seconds and invalidated via `invalidateRoleCache(roleId)` when roles are updated or deleted.
+
+**Action Alias Normalization:** The `requirePermission()` middleware normalizes legacy action aliases (`read`→`view`, `update`→`edit`) before checking, ensuring consistent permission resolution regardless of which alias is used in route definitions.
+
+**Audit Logging:** All role mutation operations (`elevate`, `assignToStore`, `assignToCompany`, `updateUserStore`, `updateUserCompany`) log structured entries via `appLogger` with the category `'Roles'`, capturing the target user, new role, and who performed the change.
 
 SSE endpoints accept the token as a query parameter (`?token=...`) since `EventSource` does not support custom headers.
 

--- a/server/src/features/roles/routes.ts
+++ b/server/src/features/roles/routes.ts
@@ -5,17 +5,20 @@
  */
 import { Router } from 'express';
 import { rolesController } from './controller.js';
-import { authenticate, restrictAppViewer } from '../../shared/middleware/auth.js';
+import { authenticate, restrictAppViewer, requirePermission, requireGlobalRole } from '../../shared/middleware/auth.js';
 
 const router = Router();
 router.use(authenticate);
 router.use(restrictAppViewer());
 
-router.get('/', rolesController.list);
-router.get('/permissions-matrix', rolesController.getPermissionsMatrix);
-router.get('/:id', rolesController.getById);
-router.post('/', rolesController.create);
-router.patch('/:id', rolesController.update);
-router.delete('/:id', rolesController.remove);
+// Read access: require settings:view permission
+router.get('/', requirePermission('settings', 'view'), rolesController.list);
+router.get('/permissions-matrix', requirePermission('settings', 'view'), rolesController.getPermissionsMatrix);
+router.get('/:id', requirePermission('settings', 'view'), rolesController.getById);
+
+// Write access: platform admin only
+router.post('/', requireGlobalRole('PLATFORM_ADMIN'), rolesController.create);
+router.patch('/:id', requireGlobalRole('PLATFORM_ADMIN'), rolesController.update);
+router.delete('/:id', requireGlobalRole('PLATFORM_ADMIN'), rolesController.remove);
 
 export default router;

--- a/server/src/features/roles/service.ts
+++ b/server/src/features/roles/service.ts
@@ -6,6 +6,7 @@
  */
 import { GlobalRole, RoleScope } from '@prisma/client';
 import { prisma } from '../../config/index.js';
+import { invalidateRoleCache } from '../../shared/middleware/index.js';
 import { RESOURCE_ACTIONS, DEFAULT_ROLE_IDS } from './types.js';
 import type { CreateRoleDTO, UpdateRoleDTO, PermissionsMap } from './types.js';
 
@@ -128,7 +129,7 @@ export const rolesService = {
             }
         }
 
-        return prisma.role.update({
+        const updated = await prisma.role.update({
             where: { id },
             data: {
                 ...(data.name && { name: data.name }),
@@ -136,6 +137,8 @@ export const rolesService = {
                 ...(data.permissions && { permissions: data.permissions as any }),
             },
         });
+        invalidateRoleCache(id);
+        return updated;
     },
 
     /**
@@ -170,7 +173,9 @@ export const rolesService = {
             }
         }
 
-        return prisma.role.delete({ where: { id } });
+        const deleted = await prisma.role.delete({ where: { id } });
+        invalidateRoleCache(id);
+        return deleted;
     },
 
     /**

--- a/server/src/features/settings/routes.ts
+++ b/server/src/features/settings/routes.ts
@@ -31,7 +31,7 @@ router.put('/store/:storeId', requirePermission('settings', 'update'), settingsC
 router.get('/company/:companyId', settingsController.getCompanySettings);
 
 // Update company settings
-router.put('/company/:companyId', settingsController.updateCompanySettings);
+router.put('/company/:companyId', requirePermission('settings', 'update'), settingsController.updateCompanySettings);
 
 // ======================
 // Field Mappings (Company-Level)
@@ -41,7 +41,7 @@ router.put('/company/:companyId', settingsController.updateCompanySettings);
 router.get('/company/:companyId/field-mappings', settingsController.getFieldMappings);
 
 // Update field mappings
-router.put('/company/:companyId/field-mappings', settingsController.updateFieldMappings);
+router.put('/company/:companyId/field-mappings', requirePermission('settings', 'update'), settingsController.updateFieldMappings);
 
 // ======================
 // Article Format (Company-Level)
@@ -51,7 +51,7 @@ router.put('/company/:companyId/field-mappings', settingsController.updateFieldM
 router.get('/company/:companyId/article-format', settingsController.getArticleFormat);
 
 // Update article format (saves to DB + pushes to AIMS)
-router.put('/company/:companyId/article-format', settingsController.updateArticleFormat);
+router.put('/company/:companyId/article-format', requirePermission('settings', 'update'), settingsController.updateArticleFormat);
 
 // ======================
 // AIMS Configuration

--- a/server/src/features/users/controller.ts
+++ b/server/src/features/users/controller.ts
@@ -220,6 +220,7 @@ export const userController = {
             if (error.message === 'STORE_NOT_FOUND') return next(notFound('Store'));
             if (error.message === 'STORE_COMPANY_MISMATCH') return next(badRequest('Store does not belong to the specified company'));
             if (error.message?.startsWith('STORE_CODE_EXISTS:')) return next(conflict(`Store code ${error.message.split(':')[1]} already exists in this company`));
+            if (error.message === 'INVALID_ROLE_ID') return next(badRequest('Invalid role ID'));
             next(error);
         }
     },
@@ -309,6 +310,7 @@ export const userController = {
             if (error.message === 'USER_NOT_FOUND') return next(notFound('User'));
             if (error.message === 'STORE_NOT_FOUND') return next(notFound('Store'));
             if (error.message === 'ALREADY_ASSIGNED') return next(conflict('User is already assigned to this store'));
+            if (error.message === 'INVALID_ROLE_ID') return next(badRequest('Invalid role ID'));
             next(error);
         }
     },
@@ -423,6 +425,7 @@ export const userController = {
             if (error.message === 'FORBIDDEN_MANAGE_COMPANY') return next(forbidden('You do not have permission to assign users to this company'));
             if (error.message === 'COMPANY_CODE_EXISTS') return next(conflict('Company code already exists'));
             if (error.message === 'ALREADY_ASSIGNED') return next(conflict('User is already assigned to this company'));
+            if (error.message === 'INVALID_ROLE_ID') return next(badRequest('Invalid role ID'));
             next(error);
         }
     },

--- a/server/src/features/users/routes.ts
+++ b/server/src/features/users/routes.ts
@@ -4,7 +4,7 @@
  * @description Thin route definitions for user management.
  */
 import { Router } from 'express';
-import { authenticate, restrictAppViewer } from '../../shared/middleware/index.js';
+import { authenticate, restrictAppViewer, requireGlobalRole, requirePermission } from '../../shared/middleware/index.js';
 import { userController } from './controller.js';
 
 const router = Router();
@@ -47,13 +47,13 @@ router.get('/check-email', userController.checkEmail);
 // ======================
 
 // Bulk deactivate users
-router.post('/bulk/deactivate', userController.bulkDeactivate);
+router.post('/bulk/deactivate', requirePermission('users', 'edit'), userController.bulkDeactivate);
 
 // Bulk activate users
-router.post('/bulk/activate', userController.bulkActivate);
+router.post('/bulk/activate', requirePermission('users', 'edit'), userController.bulkActivate);
 
 // Bulk change store role
-router.post('/bulk/role', userController.bulkChangeRole);
+router.post('/bulk/role', requirePermission('users', 'edit'), userController.bulkChangeRole);
 
 // ======================
 // User Management Routes
@@ -78,8 +78,8 @@ router.delete('/:id', userController.delete);
 // User Role Elevation
 // ======================
 
-// Elevate user role (Platform Admin or Company Admin — permission checked in service)
-router.post('/:id/elevate', userController.elevate);
+// Elevate user role (Platform Admin only)
+router.post('/:id/elevate', requireGlobalRole('PLATFORM_ADMIN'), userController.elevate);
 
 // Suspend user
 router.post('/:id/suspend', userController.suspend);

--- a/server/src/features/users/service.ts
+++ b/server/src/features/users/service.ts
@@ -8,6 +8,7 @@ import bcrypt from 'bcrypt';
 import { GlobalRole } from '@prisma/client';
 import { prisma } from '../../config/index.js';
 import { invalidateUserCache } from '../../shared/middleware/index.js';
+import { appLogger } from '../../shared/infrastructure/services/appLogger.js';
 import { userRepository } from './repository.js';
 import type {
     UserContext,
@@ -36,6 +37,12 @@ import type {
 // ======================
 // Role Helpers
 // ======================
+
+/** Validate that a roleId exists in the roles table */
+async function validateRoleId(roleId: string): Promise<void> {
+    const role = await prisma.role.findUnique({ where: { id: roleId }, select: { id: true } });
+    if (!role) throw new Error('INVALID_ROLE_ID');
+}
 
 // ======================
 // Authorization Helpers
@@ -467,6 +474,16 @@ export const userService = {
             throw new Error('EMAIL_EXISTS');
         }
 
+        // Validate company roleId
+        await validateRoleId(data.companyRoleId);
+
+        // Validate store roleIds
+        if (data.stores) {
+            for (const storeRef of data.stores) {
+                await validateRoleId(storeRef.roleId);
+            }
+        }
+
         // Only platform admins can create new companies
         if (data.company.type === 'new' && !isPlatformAdmin(currentUser)) {
             throw new Error('FORBIDDEN_CREATE_COMPANY');
@@ -646,6 +663,7 @@ export const userService = {
             ...(data.features && { features: data.features }),
         });
         invalidateUserCache(userId);
+        appLogger.info('Roles', `User store role updated`, { userId, storeId, newRoleId: data.roleId, by: currentUser.id });
         return result;
     },
 
@@ -656,6 +674,8 @@ export const userService = {
         if (!await canManageStoreOrCompany(currentUser, storeId)) {
             throw new Error('FORBIDDEN');
         }
+
+        await validateRoleId(roleId);
 
         const user = await userRepository.findById(userId);
         if (!user) throw new Error('USER_NOT_FOUND');
@@ -673,6 +693,7 @@ export const userService = {
             features,
         });
         invalidateUserCache(userId);
+        appLogger.info('Roles', `User assigned to store`, { userId, storeId, roleId, by: currentUser.id });
         return result;
     },
 
@@ -776,6 +797,7 @@ export const userService = {
         }
 
         invalidateUserCache(userId);
+        appLogger.info('Roles', `User app role changed`, { userId, previousRole: user.globalRole, newRole: data.globalRole, by: currentUser.id });
         return result;
     },
 
@@ -805,6 +827,8 @@ export const userService = {
     async assignToCompany(userId: string, data: AssignUserToCompanyDto, currentUser: UserContext) {
         const user = await userRepository.findById(userId);
         if (!user) throw new Error('USER_NOT_FOUND');
+
+        await validateRoleId(data.companyRoleId);
 
         if (data.company.type === 'new' && !isPlatformAdmin(currentUser)) {
             throw new Error('FORBIDDEN_CREATE_COMPANY');
@@ -855,6 +879,7 @@ export const userService = {
             });
 
             invalidateUserCache(userId);
+            appLogger.info('Roles', `User assigned to company`, { userId, companyId, roleId: data.companyRoleId, by: currentUser.id });
             return result;
         });
     },
@@ -882,6 +907,7 @@ export const userService = {
 
         const result = await userRepository.updateUserCompany(userId, companyId, updateData);
         invalidateUserCache(userId);
+        appLogger.info('Roles', `User company role updated`, { userId, companyId, newRoleId: data.companyRoleId, by: currentUser.id });
         return result;
     },
 

--- a/server/src/shared/middleware/__tests__/auth.middleware.test.ts
+++ b/server/src/shared/middleware/__tests__/auth.middleware.test.ts
@@ -18,7 +18,7 @@ vi.mock('jsonwebtoken', () => ({
 }));
 
 import jwt from 'jsonwebtoken';
-import { authenticate, authorize, requireGlobalRole, requirePermission } from '../auth.js';
+import { authenticate, requireGlobalRole, requirePermission } from '../auth.js';
 import { prisma } from '../../../config/index.js';
 
 function createMocks(overrides: Partial<Request> = {}) {
@@ -74,27 +74,6 @@ describe('requireGlobalRole', () => {
         req.user = { id: '1', email: 'a@b.com', globalRole: null, stores: [], companies: [] };
         mw(req, res, next);
         expect(next).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining('global role') }));
-    });
-});
-
-describe('authorize', () => {
-    beforeEach(() => vi.clearAllMocks());
-
-    it('should allow PLATFORM_ADMIN', async () => {
-        const mw = authorize('Admin');
-        const { req, res, next } = createMocks();
-        req.user = { id: '1', email: 'a@b.com', globalRole: 'PLATFORM_ADMIN' as any, stores: [], companies: [] };
-        await mw(req, res, next);
-        expect(next).toHaveBeenCalledWith();
-    });
-
-    it('should reject non-matching role', async () => {
-        const mw = authorize('Admin');
-        const { req, res, next } = createMocks();
-        req.user = { id: '1', email: 'a@b.com', globalRole: null, stores: [{ id: 's1', roleId: 'role-viewer', companyId: 'c1' }], companies: [] };
-        (prisma.role.findUnique as any).mockResolvedValue({ name: 'Viewer' });
-        await mw(req, res, next);
-        expect(next).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining('permissions') }));
     });
 });
 

--- a/server/src/shared/middleware/auth.ts
+++ b/server/src/shared/middleware/auth.ts
@@ -190,21 +190,20 @@ export const authenticate = async (
 
         // For companies where user has allStoresAccess, expand into stores array
         // so all downstream services that check req.user.stores work correctly.
-        const allStoresCompanyIds = companies
-            .filter(c => c.allStoresAccess)
-            .map(c => c.id);
+        const allStoresCompanies = companies.filter(c => c.allStoresAccess);
 
-        if (allStoresCompanyIds.length > 0) {
+        if (allStoresCompanies.length > 0) {
             const existingStoreIds = new Set(stores.map(s => s.id));
+            const companyRoleMap = new Map(allStoresCompanies.map(c => [c.id, c.roleId]));
             const companyStores = await prisma.store.findMany({
-                where: { companyId: { in: allStoresCompanyIds }, isActive: true },
+                where: { companyId: { in: allStoresCompanies.map(c => c.id) }, isActive: true },
                 select: { id: true, companyId: true },
             });
             for (const cs of companyStores) {
                 if (!existingStoreIds.has(cs.id)) {
                     stores.push({
                         id: cs.id,
-                        roleId: 'role-admin',  // Company admins with allStoresAccess get admin role
+                        roleId: companyRoleMap.get(cs.companyId) || 'role-viewer',
                         companyId: cs.companyId,
                     });
                 }
@@ -246,35 +245,13 @@ export const requireGlobalRole = (...allowedRoles: GlobalRole[]) => {
     };
 };
 
-// Role-based authorization middleware (checks by role name from DB)
-export const authorize = (...allowedRoleNames: string[]) => {
-    return async (req: Request, _res: Response, next: NextFunction): Promise<void> => {
-        if (!req.user) {
-            next(unauthorized('Authentication required'));
-            return;
-        }
-
-        // Platform admin has all access
-        if (req.user.globalRole === GlobalRole.PLATFORM_ADMIN) {
-            next();
-            return;
-        }
-
-        // Look up role names for user's stores
-        for (const store of req.user.stores) {
-            const role = await prisma.role.findUnique({
-                where: { id: store.roleId },
-                select: { name: true },
-            });
-            if (role && allowedRoleNames.includes(role.name)) {
-                next();
-                return;
-            }
-        }
-
-        next(forbidden('Insufficient permissions'));
-    };
-};
+// Self-service URL patterns allowed for APP_VIEWER even on mutating methods
+const APP_VIEWER_SELF_SERVICE_PATTERNS = [
+    '/users/me',
+    '/auth/change-password',
+    '/auth/logout',
+    '/auth/refresh',
+];
 
 // App Viewer restriction middleware — blocks mutating requests for APP_VIEWER users
 export const restrictAppViewer = () => {
@@ -288,9 +265,7 @@ export const restrictAppViewer = () => {
         if (req.user.globalRole === GlobalRole.APP_VIEWER && req.method !== 'GET') {
             // Use originalUrl for correct matching across sub-routers
             const url = req.originalUrl || req.url;
-            // Allow self-service: own profile, context switch, auth operations
-            const selfServicePatterns = ['/users/me', '/auth/change-password', '/auth/logout', '/auth/refresh'];
-            const isSelfService = selfServicePatterns.some(p => url.includes(p));
+            const isSelfService = APP_VIEWER_SELF_SERVICE_PATTERNS.some(p => url.includes(p));
 
             if (!isSelfService) {
                 next(forbidden('App Viewer accounts have read-only access'));
@@ -302,8 +277,12 @@ export const restrictAppViewer = () => {
     };
 };
 
+// Normalize legacy action aliases: read→view, update→edit
+const ACTION_ALIASES: Partial<Record<Action, Action>> = { read: 'view', update: 'edit' };
+
 // Permission-based authorization (DB-backed)
 export const requirePermission = (resource: Resource, action: Action) => {
+    const normalizedAction = ACTION_ALIASES[action] || action;
     return async (req: Request, _res: Response, next: NextFunction): Promise<void> => {
         if (!req.user) {
             next(unauthorized('Authentication required'));
@@ -316,21 +295,21 @@ export const requirePermission = (resource: Resource, action: Action) => {
             return;
         }
 
-        // Check store role permissions
+        // Check store role permissions (check both original and normalized action)
         for (const store of req.user.stores) {
             const permissions = await getRolePermissions(store.roleId);
             const resourcePerms = permissions[resource] || [];
-            if (resourcePerms.includes(action)) {
+            if (resourcePerms.includes(normalizedAction) || resourcePerms.includes(action)) {
                 next();
                 return;
             }
         }
 
-        // Fallback: allStoresAccess companies get admin permissions
+        // Fallback: allStoresAccess companies use their actual company role permissions
         for (const company of req.user.companies) {
             if (company.allStoresAccess) {
-                const adminPerms = await getRolePermissions('role-admin');
-                if (adminPerms[resource]?.includes(action)) {
+                const companyPerms = await getRolePermissions(company.roleId);
+                if (companyPerms[resource]?.includes(normalizedAction) || companyPerms[resource]?.includes(action)) {
                     next();
                     return;
                 }

--- a/server/src/shared/middleware/index.ts
+++ b/server/src/shared/middleware/index.ts
@@ -1,3 +1,3 @@
 export { errorHandler, AppError, badRequest, unauthorized, forbidden, notFound, conflict, unprocessable, tooManyRequests, serviceUnavailable } from './errorHandler.js';
 export { notFoundHandler } from './notFoundHandler.js';
-export { authenticate, authorize, requireGlobalRole, requirePermission, restrictAppViewer, invalidateUserCache, invalidateRoleCache } from './auth.js';
+export { authenticate, requireGlobalRole, requirePermission, restrictAppViewer, invalidateUserCache, invalidateRoleCache } from './auth.js';

--- a/src/features/settings/presentation/UsersSettingsTab.tsx
+++ b/src/features/settings/presentation/UsersSettingsTab.tsx
@@ -164,29 +164,29 @@ export function UsersSettingsTab() {
         fetchUsers();
     };
 
-    /** Map roleId to a translation-friendly key (e.g., 'role-admin' → 'admin') */
-    const roleIdToKey = (roleId: string | undefined): string | null => {
-        if (!roleId) return null;
-        return roleId.startsWith('role-') ? roleId.substring(5) : roleId;
-    };
-
-    // Role color helper — supports both legacy CompanyRole and new roleId-based keys
-    const getRoleColor = (role: string) => {
-        switch (role) {
-            case 'PLATFORM_ADMIN': return 'secondary';
-            case 'COMPANY_ADMIN': return 'primary';
-            case 'admin': return 'error';
-            case 'manager': return 'warning';
-            case 'employee': return 'info';
-            case 'viewer': return 'default';
-            // Legacy fallbacks
-            case 'STORE_ADMIN': return 'error';
-            case 'STORE_MANAGER': return 'warning';
-            case 'STORE_EMPLOYEE': return 'info';
-            case 'STORE_VIEWER': return 'default';
-            case 'VIEWER': return 'default';
-            default: return 'default';
+    /** Compute display role key and color for a user, with scope context */
+    const getUserRoleDisplay = (user: any): { roleKey: string; color: string; isAdminLevel: boolean } => {
+        // App-level roles
+        if (user.globalRole === 'PLATFORM_ADMIN') {
+            return { roleKey: 'platform_admin', color: 'secondary', isAdminLevel: true };
         }
+        if (user.globalRole === 'APP_VIEWER') {
+            return { roleKey: 'viewer', color: 'default', isAdminLevel: false };
+        }
+        // Company-level: check if user has company admin role via roleId
+        const firstCompany = user.companies?.[0];
+        if (firstCompany?.roleId === 'role-admin' && firstCompany?.allStoresAccess) {
+            return { roleKey: 'company_admin', color: 'primary', isAdminLevel: true };
+        }
+        // Store-level role
+        const firstStore = user.stores?.[0];
+        const roleId = firstCompany?.roleId || firstStore?.roleId;
+        if (roleId) {
+            const key = roleId.startsWith('role-') ? roleId.substring(5) : roleId;
+            const colorMap: Record<string, string> = { admin: 'error', manager: 'warning', employee: 'info', viewer: 'default' };
+            return { roleKey: key, color: colorMap[key] || 'default', isAdminLevel: key === 'admin' };
+        }
+        return { roleKey: 'viewer', color: 'default', isAdminLevel: false };
     };
 
     // Feature icon helper
@@ -274,17 +274,8 @@ export function UsersSettingsTab() {
                             </Typography>
                         ) : (
                             users.map((user) => {
+                                const { roleKey, color, isAdminLevel } = getUserRoleDisplay(user);
                                 const firstStore = user.stores?.[0];
-                                const firstCompany = user.companies?.[0];
-                                const companyRole = firstCompany?.role;
-                                const isAdminCompanyRole = companyRole === 'COMPANY_ADMIN' || companyRole === 'SUPER_USER';
-                                const isAllStoresRole = isAdminCompanyRole;
-                                const userRole = user.globalRole
-                                    || (isAdminCompanyRole ? 'COMPANY_ADMIN' : null)
-                                    || roleIdToKey(firstStore?.roleId)
-                                    || companyRole
-                                    || 'viewer';
-                                const isAdminLevel = user.globalRole === 'PLATFORM_ADMIN' || isAllStoresRole;
                                 const userFeatures = isAdminLevel
                                     ? ['dashboard', 'spaces', 'conference', 'people']
                                     : (firstStore?.features || ['dashboard']);
@@ -313,7 +304,7 @@ export function UsersSettingsTab() {
                                             </Stack>
                                             <Divider sx={{ my: 1.5 }} />
                                             <Stack direction="row" gap={0.75} flexWrap="wrap" alignItems="center">
-                                                <Chip label={t(`roles.${userRole.toLowerCase()}`)} color={getRoleColor(userRole) as any} variant="filled" size="small" sx={{ p: 1, px: 1.5 }} />
+                                                <Chip label={t(`roles.${roleKey}`)} color={color as any} variant="filled" size="small" sx={{ p: 1, px: 1.5 }} />
                                                 <Chip label={user.isActive ? t('common.status.active') : t('common.status.inactive')} color={user.isActive ? 'success' : 'default'} variant="outlined" size="small" sx={{ p: 1, px: 1.5 }} />
                                             </Stack>
                                             <Stack direction="row" gap={0.5} flexWrap="wrap" sx={{ mt: 1 }}>
@@ -387,18 +378,8 @@ export function UsersSettingsTab() {
                                     </TableRow>
                                 ) : (
                                     users.map((user) => {
-                                        // Compute display role: globalRole > COMPANY_ADMIN/SUPER_USER > store roleId > companyRole > fallback
+                                        const { roleKey, color, isAdminLevel } = getUserRoleDisplay(user);
                                         const firstStore = user.stores?.[0];
-                                        const firstCompany = user.companies?.[0];
-                                        const companyRole = firstCompany?.role;
-                                        const isAdminCompanyRole = companyRole === 'COMPANY_ADMIN' || companyRole === 'SUPER_USER';
-                                        const isAllStoresRole = isAdminCompanyRole;
-                                        const userRole = user.globalRole
-                                            || (isAdminCompanyRole ? 'COMPANY_ADMIN' : null)
-                                            || roleIdToKey(firstStore?.roleId)
-                                            || companyRole
-                                            || 'viewer';
-                                        const isAdminLevel = user.globalRole === 'PLATFORM_ADMIN' || isAllStoresRole;
                                         const userFeatures = isAdminLevel
                                             ? ['dashboard', 'spaces', 'conference', 'people']
                                             : (firstStore?.features || ['dashboard']);
@@ -419,8 +400,8 @@ export function UsersSettingsTab() {
                                                 </TableCell>
                                                 <TableCell>
                                                     <Chip
-                                                        label={t(`roles.${userRole.toLowerCase()}`)}
-                                                        color={getRoleColor(userRole) as any}
+                                                        label={t(`roles.${roleKey}`)}
+                                                        color={color as any}
                                                         variant='filled'
                                                         size="small"
                                                         sx={{ p: 1, px: 1.5 }}

--- a/src/features/settings/presentation/userDialog/useUserDialogState.ts
+++ b/src/features/settings/presentation/userDialog/useUserDialogState.ts
@@ -572,16 +572,30 @@ export function useUserDialogState({ open, onSave, user, profileMode }: Params) 
 
     const getRoleLabel = useCallback(() => {
         if (userData?.globalRole === 'PLATFORM_ADMIN') return t('roles.platform_admin');
-        // Check company-level roleId
-        const companyRoleId = userData?.companies?.[0]?.roleId;
-        if (companyRoleId) {
-            const roleKey = companyRoleId.startsWith('role-') ? companyRoleId.substring(5) : companyRoleId;
-            return t(`roles.${roleKey}`, roleKey);
+        if (userData?.globalRole === 'APP_VIEWER') return t('settings.users.role.appViewer');
+
+        // Find the highest-priority role across all company and store assignments
+        const ROLE_PRIORITY: Record<string, number> = { 'role-admin': 4, 'role-manager': 3, 'role-employee': 2, 'role-viewer': 1 };
+        let highestRole = '';
+        let highestPriority = 0;
+
+        for (const c of userData?.companies || []) {
+            const rid = c?.roleId;
+            if (rid && (ROLE_PRIORITY[rid] || 0) > highestPriority) {
+                highestPriority = ROLE_PRIORITY[rid] || 0;
+                highestRole = rid;
+            }
         }
-        // Check store-level roleId
-        const storeRoleId = userData?.stores?.[0]?.roleId;
-        if (storeRoleId) {
-            const roleKey = storeRoleId.startsWith('role-') ? storeRoleId.substring(5) : storeRoleId;
+        for (const s of userData?.stores || []) {
+            const rid = s?.roleId;
+            if (rid && (ROLE_PRIORITY[rid] || 0) > highestPriority) {
+                highestPriority = ROLE_PRIORITY[rid] || 0;
+                highestRole = rid;
+            }
+        }
+
+        if (highestRole) {
+            const roleKey = highestRole.startsWith('role-') ? highestRole.substring(5) : highestRole;
             return t(`roles.${roleKey}`, roleKey);
         }
         return t('roles.viewer');


### PR DESCRIPTION
## Summary

Implements all 4 phases of the [roles audit remediation plan](docs/plans/2026-03-01-roles-audit-remediation.md) addressing 16 findings across security, functional, and polish categories.

### Phase 1 — Critical Security Fixes
- Protect roles CRUD endpoints with `requireGlobalRole('PLATFORM_ADMIN')` and `requirePermission('settings', 'view')`
- Fix allStoresAccess privilege escalation — company managers no longer silently get admin permissions on expanded stores
- Add `requireGlobalRole('PLATFORM_ADMIN')` middleware to elevate endpoint
- Validate roleId exists in DB before creating UserCompany/UserStore (returns 400 instead of 500)

### Phase 2 — Functional Fixes
- Remove dead `authorize()` middleware and its tests
- Add `requirePermission('settings', 'update')` to company settings, field-mappings, and article-format PUT routes
- Add `requirePermission('users', 'edit')` to bulk user operations
- Add structured audit logging (`appLogger.info('Roles', ...)`) for all role mutation paths

### Phase 3 — Improvements
- Extract APP_VIEWER self-service URL patterns to `APP_VIEWER_SELF_SERVICE_PATTERNS` constant
- Fix `getRoleLabel()` to scan all company/store assignments for highest-priority role
- Fix user table role chips — broken `.role` field replaced with `getUserRoleDisplay()` helper using proper `roleId`-based detection with scope context
- Normalize `read`→`view` and `update`→`edit` action aliases in `requirePermission()`

### Phase 4 — Polish
- Add `invalidateRoleCache()` calls to roles service `update()` and `remove()` methods
- Feature arrays already validated via Zod schemas (no change needed)

## Test plan
- [x] All 1221 client unit tests pass
- [x] All 85 server unit tests pass
- [x] TypeScript compilation clean (client + server)
- [ ] Manual: verify non-admin cannot access roles CRUD endpoints
- [ ] Manual: verify allStoresAccess company manager gets correct (not admin) permissions
- [ ] Manual: verify role chips show scope context in user table

🤖 Generated with [Claude Code](https://claude.com/claude-code)