### PR TITLE
fix: conference simple mode — correct AIMS page flip API and Available/Busy UI

### DIFF
--- a/docs/plans/2026-03-03-aims-dashboard-card-plan.md
+++ b/docs/plans/2026-03-03-aims-dashboard-card-plan.md
@@ -1,0 +1,291 @@
+# AIMS Dashboard Card — Full Overview Replica
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the lightweight AIMS dashboard card with a full overview replica showing all 6 AIMS health categories (gateways, labels, updates, battery, signal, models) using data from the `storeSummary` endpoint, with unified design polish across all dashboard cards.
+
+**Architecture:** The `DashboardAimsCard` gets a full rewrite to consume `storeSummary` data (same endpoint used by AimsOverviewTab). The `DashboardPage` switches from `useGateways()` + `useLabelsOverview()` to `useAimsOverview()` for the AIMS card. The card uses the `frontend-design` skill for distinctive visual treatment while respecting the existing dashboard design language. All dashboard cards get minor unified design alignment.
+
+**Tech Stack:** React 19, MUI 7 (Grid, Card, LinearProgress, Chip, Stack), Zustand, i18next, `useAimsOverview` hook
+
+---
+
+## Task 1: Create Branch and Update DashboardPage Data Fetching
+
+**Files:**
+- Modify: `src/features/dashboard/DashboardPage.tsx`
+
+**Step 1: Create feature branch**
+
+```bash
+git checkout main && git pull
+git checkout -b feat/aims-dashboard-overview
+```
+
+**Step 2: Update DashboardPage to use `useAimsOverview` instead of separate hooks**
+
+In `src/features/dashboard/DashboardPage.tsx`:
+
+Replace these imports:
+```typescript
+import { useGateways } from '@features/aims-management/application/useGateways';
+import { useLabelsOverview } from '@features/aims-management/application/useLabelsOverview';
+```
+
+With:
+```typescript
+import { useAimsOverview } from '@features/aims-management/application/useAimsOverview';
+```
+
+Replace these lines (around line 67-68):
+```typescript
+const { gateways, fetchGateways: fetchAimsGateways } = useGateways(activeStoreId);
+const { stats: aimsLabelStats, fetchLabels: fetchAimsLabels } = useLabelsOverview(activeStoreId);
+```
+
+With:
+```typescript
+const { storeSummary: aimsStoreSummary, labelModels: aimsLabelModels, fetchOverview: fetchAimsOverview } = useAimsOverview(activeStoreId);
+```
+
+Replace the AIMS fetch calls in useEffect (around line 76-79):
+```typescript
+if (isAimsEnabled) {
+    fetchAimsGateways();
+    fetchAimsLabels();
+}
+```
+
+With:
+```typescript
+if (isAimsEnabled) {
+    fetchAimsOverview();
+}
+```
+
+Remove the `aimsGatewayStats` useMemo block entirely (lines 122-129).
+
+Replace the `DashboardAimsCard` usage (around line 236-248) with:
+```tsx
+{isAimsEnabled && (
+    <Grid size={{ xs: 12 }}>
+        <DashboardAimsCard
+            storeSummary={aimsStoreSummary}
+            labelModels={aimsLabelModels}
+            isMobile={isMobile}
+        />
+    </Grid>
+)}
+```
+
+Note: Card now spans full width (`xs: 12` only, no `md: 6`) since it's a rich overview.
+
+**Step 3: Verify no TypeScript errors**
+
+```bash
+npx tsc --noEmit --project tsconfig.json 2>&1 | head -20
+```
+
+Expected: Errors about DashboardAimsCard props mismatch (will be fixed in Task 2).
+
+**Step 4: Commit**
+
+```bash
+git add src/features/dashboard/DashboardPage.tsx
+git commit -m "refactor: switch dashboard AIMS card to useAimsOverview data source"
+```
+
+---
+
+## Task 2: Rewrite DashboardAimsCard as Full Overview Replica
+
+**Files:**
+- Rewrite: `src/features/dashboard/components/DashboardAimsCard.tsx`
+
+**Step 1: Invoke frontend-design skill for the card**
+
+Use the `frontend-design` skill with this argument:
+```
+Rewrite DashboardAimsCard as a full AIMS overview replica embedded in the dashboard.
+The card receives `storeSummary` (object with AIMS store health metrics) and `labelModels` (array of label type objects).
+
+Data fields from storeSummary:
+- onlineGwCount, offlineGwCount (gateway health)
+- totalLabelCount, onlineLabelCount, offlineLabelCount (label health)
+- updatedLabelCount, inProgressLabelCount, notUpdatedLabelCount (update progress)
+- goodBatteryCount, lowBatteryCount (battery health)
+- excellentSignalLabelCount, goodSignalLabelCount, badSignalLabelCount (signal quality)
+
+labelModels: array of { labelType/type: string, count: number }
+
+Design requirements:
+- MUST match existing dashboard card design language (see DashboardSpacesCard, DashboardPeopleCard, DashboardConferenceCard patterns)
+- Header: RouterIcon + "AIMS Management" title + "To AIMS →" navigation link
+- Desktop: 6 sub-sections in 2x3 grid, each with bgcolor 'background.default', borderRadius 2
+  1. Gateway Health — progress bar (success/error) + online/offline counts
+  2. Label Health — progress bar (success/error) + online/offline counts
+  3. Update Progress — progress bar (success) + updated/in-progress/failed counts
+  4. Battery Health — progress bar (success/warning) + good/low counts
+  5. Signal Quality — progress bar (success/info/error) + excellent/good/bad counts
+  6. Label Models — Chip list with type:count
+- Mobile: Tappable header → hero number (total gateways) → gateway health bar → MobileStatTile rows for all categories → battery/signal chips
+- Each sub-section icon uses colored rounded box (same pattern as AimsOverviewTab)
+- All numeric ratios use dir="ltr" for RTL support
+- Progress bars: height 8, borderRadius 4
+- Use MobileStatTile component for mobile stat tiles
+- Card sx={{ height: '100%', position: 'relative', overflow: 'visible' }} on desktop
+- CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }} on desktop
+- Navigation: navigate('/aims-management')
+- Show "no data" states gracefully when storeSummary is null/undefined
+- Translation keys: use existing aims.* keys (aims.gatewayHealth, aims.labelHealth, aims.online, aims.offline, aims.batteryHealth, aims.batteryGood, aims.batteryLow, aims.signalDistribution, aims.signalExcellent, aims.signalGood, aims.signalBad, aims.productUpdates, aims.success, aims.failed, aims.labelTypes, aims.totalGateways, aims.totalLabels, aims.gateways, aims.labels)
+- Add new translation key: dashboard.toAimsManagement for the navigation link
+
+MUI imports needed: Box, Card, CardContent, Typography, Stack, Grid, LinearProgress, Chip, useMediaQuery, useTheme
+Icon imports: RouterIcon, ArrowForwardIcon, LabelIcon, BatteryChargingFullOutlined, SignalCellularAltOutlined, UpdateOutlined, CategoryOutlined
+Other imports: useTranslation, useNavigate, MobileStatTile
+
+Props interface:
+interface DashboardAimsCardProps {
+    storeSummary: any;
+    labelModels: any[];
+    isMobile?: boolean;
+}
+```
+
+The frontend-design skill will generate the complete component. After it produces the code, write it to `src/features/dashboard/components/DashboardAimsCard.tsx`.
+
+**Step 2: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit --project tsconfig.json 2>&1 | head -20
+```
+
+Expected: PASS (no errors)
+
+**Step 3: Commit**
+
+```bash
+git add src/features/dashboard/components/DashboardAimsCard.tsx
+git commit -m "feat: rewrite AIMS dashboard card as full overview replica"
+```
+
+---
+
+## Task 3: Add Missing Translation Keys
+
+**Files:**
+- Modify: `src/locales/en/common.json`
+- Modify: `src/locales/he/common.json`
+
+**Step 1: Add any new translation keys needed by the card**
+
+In the `dashboard` section of both locale files, add:
+```json
+"toAimsManagement": "To AIMS Management"
+```
+
+Hebrew:
+```json
+"toAimsManagement": "לניהול AIMS"
+```
+
+Check if the frontend-design skill output uses any keys not already in the locale files. The existing `aims.*` keys should cover most needs. Add any missing ones to BOTH files.
+
+**Step 2: Commit**
+
+```bash
+git add src/locales/en/common.json src/locales/he/common.json
+git commit -m "feat: add dashboard AIMS card translation keys"
+```
+
+---
+
+## Task 4: Dashboard Unified Design Polish
+
+**Files:**
+- Modify: `src/features/dashboard/components/DashboardSpacesCard.tsx`
+- Modify: `src/features/dashboard/components/DashboardConferenceCard.tsx`
+- Modify: `src/features/dashboard/components/DashboardPeopleCard.tsx`
+- Modify: `src/features/dashboard/components/MobileStatTile.tsx` (if needed)
+
+**Step 1: Invoke frontend-design skill for unified polish**
+
+Use the `frontend-design` skill to review and align all dashboard cards:
+```
+Review and polish the existing dashboard cards (DashboardSpacesCard, DashboardConferenceCard, DashboardPeopleCard) to create a unified, polished dashboard design that aligns with the new rich AIMS card.
+
+Focus areas:
+- Consistent spacing, typography, and color usage across all cards
+- Matching sub-section styling (bgcolor background.default, borderRadius 2)
+- Consistent icon treatment (colored rounded box for section headers)
+- Consistent progress bar styling (height 8, borderRadius 4)
+- Mobile stat tile consistency
+- RTL support (dir="ltr" on all numeric values)
+- DO NOT change functionality or data — only visual polish
+- Keep changes minimal and targeted — don't rewrite cards that are already well-structured
+```
+
+**Step 2: Verify build**
+
+```bash
+npm run build 2>&1 | tail -5
+```
+
+Expected: Build succeeds
+
+**Step 3: Commit**
+
+```bash
+git add src/features/dashboard/components/
+git commit -m "style: unified dashboard card design polish"
+```
+
+---
+
+## Task 5: Final Verification and PR
+
+**Step 1: Full build check**
+
+```bash
+npm run build 2>&1 | tail -10
+```
+
+Expected: Build succeeds with no errors
+
+**Step 2: Server TypeScript check**
+
+```bash
+cd server && npx tsc --noEmit 2>&1 | tail -10
+```
+
+Expected: No errors (server wasn't changed)
+
+**Step 3: Push and create PR**
+
+```bash
+git push -u origin feat/aims-dashboard-overview
+```
+
+Create PR with:
+- Title: `feat: AIMS dashboard card full overview replica`
+- Body: Summary of changes, link to design doc
+- Base: `main`
+
+**Step 4: Commit**
+
+No commit needed — PR creation is the final step.
+
+---
+
+## Files Changed Summary
+
+| File | Action |
+|------|--------|
+| `src/features/dashboard/DashboardPage.tsx` | Modify — switch to useAimsOverview, full-width card |
+| `src/features/dashboard/components/DashboardAimsCard.tsx` | Rewrite — full overview replica |
+| `src/locales/en/common.json` | Add translation keys |
+| `src/locales/he/common.json` | Add translation keys |
+| `src/features/dashboard/components/DashboardSpacesCard.tsx` | Polish — unified design |
+| `src/features/dashboard/components/DashboardConferenceCard.tsx` | Polish — unified design |
+| `src/features/dashboard/components/DashboardPeopleCard.tsx` | Polish — unified design |
+| `src/features/dashboard/components/MobileStatTile.tsx` | Polish — if needed |

--- a/docs/plans/2026-03-03-company-wizard-plan.md
+++ b/docs/plans/2026-03-03-company-wizard-plan.md
@@ -1,0 +1,729 @@
+# Company Creation Wizard — 6-Step Stepper Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the 2-step company creation wizard with a comprehensive 6-step validated stepper. All features disabled by default. Multi-store selection, article format fetch/confirm, field mapping, and feature selection with dependency validation. Existing companies (dev + production) preserved with new UI. Article safety: only People mode writes articles to AIMS; all other modes sync FROM AIMS and never delete existing articles.
+
+**Architecture:** The wizard becomes a 6-step MUI Stepper: (1) AIMS Connection + Company Info, (2) Multi-Store Selection, (3) Article Format Fetch & Confirm, (4) Field Mapping, (5) Feature Selection, (6) Review & Create. The server `createCompany` endpoint is extended to accept the full payload (stores[], articleFormat, fieldMapping, features). Edit mode presents the same sections as tabs. DEFAULT_COMPANY_FEATURES changes to all-false. Backward compatibility for existing companies via `ALL_FEATURES_ENABLED` fallback.
+
+**Tech Stack:** React 19, MUI 7 (Stepper, Dialog, Grid, TextField, Select, Switch, Chip), React Hook Form + Zod, i18next, Express, Prisma
+
+---
+
+## Critical Safety Rule: Article Protection
+
+**In People mode:** The server is the source of truth. Articles are created/updated/deleted by the server based on person assignments.
+
+**In all other modes (Spaces, Conference, Labels):** AIMS is the source of truth. The app syncs FROM AIMS, never deletes articles. Conference rooms auto-detect from articles with `C+number` pattern. Spaces show all other articles.
+
+This means:
+- Company creation MUST NOT push/delete any articles to AIMS
+- Feature toggling MUST NOT trigger article deletion
+- Only explicit sync actions in People mode should write articles
+
+---
+
+## Task 1: Create Branch and Update DEFAULT_COMPANY_FEATURES
+
+**Files:**
+- Modify: `server/src/shared/utils/featureResolution.ts`
+
+**Step 1: Create feature branch**
+
+```bash
+git checkout main && git pull
+git checkout -b feat/company-wizard-redesign
+```
+
+**Step 2: Change DEFAULT_COMPANY_FEATURES to all-false**
+
+In `server/src/shared/utils/featureResolution.ts`, change lines 23-30:
+
+```typescript
+export const DEFAULT_COMPANY_FEATURES: CompanyFeatures = {
+    spacesEnabled: false,
+    peopleEnabled: false,
+    conferenceEnabled: false,
+    simpleConferenceMode: false,
+    labelsEnabled: false,
+    aimsManagementEnabled: false,
+};
+```
+
+**Important:** The `ALL_FEATURES_ENABLED` constant (line 63-70) and the `extractCompanyFeatures` backward-compat logic MUST remain unchanged — this protects existing companies.
+
+**Step 3: Verify server compiles**
+
+```bash
+cd server && npx tsc --noEmit 2>&1 | tail -5
+```
+
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add server/src/shared/utils/featureResolution.ts
+git commit -m "feat: change default company features to all-disabled"
+```
+
+---
+
+## Task 2: Extend Server Create Company Endpoint
+
+**Files:**
+- Modify: `server/src/features/companies/types.ts`
+- Modify: `server/src/features/companies/service.ts`
+- Modify: `server/src/features/companies/controller.ts`
+
+**Step 1: Extend Zod schema for full creation payload**
+
+In `server/src/features/companies/types.ts`, add a new schema for the stores array:
+
+```typescript
+/** Store to create alongside company */
+export const createStoreSchema = z.object({
+    code: z.string().min(1, 'Store code is required'),
+    name: z.string().max(100).optional(),
+    timezone: z.string().default('UTC'),
+});
+
+/** Extended create company schema with multi-store + config */
+export const createCompanyFullSchema = createCompanySchema.extend({
+    stores: z.array(createStoreSchema).min(1, 'At least one store is required'),
+    articleFormat: z.record(z.unknown()).optional(),
+    fieldMapping: z.record(z.unknown()).optional(),
+});
+```
+
+Add the DTO:
+```typescript
+export interface CreateCompanyFullDto extends CreateCompanyDto {
+    stores: Array<{ code: string; name?: string; timezone?: string }>;
+    articleFormat?: Record<string, unknown>;
+    fieldMapping?: Record<string, unknown>;
+}
+```
+
+**Step 2: Extend service to create multiple stores + save config**
+
+In `server/src/features/companies/service.ts`, modify the `createCompany` method to:
+
+1. Accept the extended DTO
+2. Create all stores in a loop (not just one)
+3. Save `articleFormat` to `company.settings.solumArticleFormat` if provided
+4. Save `fieldMapping` to `company.settings.solumMappingConfig` if provided
+5. **MUST NOT** push articles to AIMS during creation
+
+The existing `createCompany` already creates one store. Extend it:
+
+```typescript
+// After company creation, create all requested stores
+for (const storeData of dto.stores) {
+    await prisma.store.create({
+        data: {
+            companyId: company.id,
+            code: storeData.code,
+            name: storeData.name || storeData.code,
+            timezone: storeData.timezone || 'UTC',
+            syncEnabled: false, // Don't auto-sync on creation
+            isActive: true,
+        },
+    });
+}
+
+// Save article format and field mapping to company settings
+if (dto.articleFormat || dto.fieldMapping) {
+    const currentSettings = (company.settings as Record<string, unknown>) || {};
+    const updatedSettings = {
+        ...currentSettings,
+        ...(dto.articleFormat ? { solumArticleFormat: dto.articleFormat } : {}),
+        ...(dto.fieldMapping ? { solumMappingConfig: dto.fieldMapping } : {}),
+    };
+    await prisma.company.update({
+        where: { id: company.id },
+        data: { settings: updatedSettings as any },
+    });
+}
+```
+
+**Step 3: Update controller to parse extended schema**
+
+In `server/src/features/companies/controller.ts`, the `create` handler should parse with `createCompanyFullSchema` instead of `createCompanySchema`. Fall back gracefully — if `stores` is not provided, use the legacy single-store creation.
+
+**Step 4: Verify server compiles**
+
+```bash
+cd server && npx tsc --noEmit 2>&1 | tail -5
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add server/src/features/companies/
+git commit -m "feat: extend company creation to accept multi-store, article format, and field mapping"
+```
+
+---
+
+## Task 3: Client-Side Wizard Step Components — Step 1 (Connection)
+
+**Files:**
+- Create: `src/features/settings/presentation/companyDialog/steps/ConnectionStep.tsx`
+
+**Step 1: Create the steps directory**
+
+```bash
+mkdir -p src/features/settings/presentation/companyDialog/steps
+```
+
+**Step 2: Create ConnectionStep component**
+
+This step collects:
+- Company code (validates uniqueness via debounced API)
+- Company name, location (optional)
+- AIMS cluster (C1 / Common radio group)
+- AIMS username, password
+- "Test Connection" button — required before proceeding
+
+Props:
+```typescript
+interface ConnectionStepProps {
+    formData: WizardFormData;
+    onUpdate: (data: Partial<WizardFormData>) => void;
+    onConnectionTest: () => Promise<boolean>;
+    connectionStatus: 'idle' | 'testing' | 'connected' | 'failed';
+    codeAvailable: boolean | null;
+    codeChecking: boolean;
+}
+```
+
+The component uses MUI TextField, RadioGroup, Button. On "Test Connection" click, calls `onConnectionTest()` which the parent wizard handles.
+
+Validation: code must be 3-20 uppercase, name required, AIMS fields required.
+
+Connection must succeed (`connectionStatus === 'connected'`) before the parent wizard allows "Next".
+
+**Step 3: Commit**
+
+```bash
+git add src/features/settings/presentation/companyDialog/steps/ConnectionStep.tsx
+git commit -m "feat: add wizard ConnectionStep component"
+```
+
+---
+
+## Task 4: Client-Side Wizard Step Components — Step 2 (Stores)
+
+**Files:**
+- Create: `src/features/settings/presentation/companyDialog/steps/StoreSelectionStep.tsx`
+
+**Step 1: Create StoreSelectionStep component**
+
+This step shows:
+- List of stores fetched from AIMS (passed as prop)
+- Each store: checkbox + store code + label count + gateway count
+- Selected stores get inline fields: friendly name (TextField), timezone (Autocomplete)
+- At least 1 store must be selected
+
+Props:
+```typescript
+interface StoreSelectionStepProps {
+    aimsStores: AimsStoreInfo[];  // from fetchAimsStores()
+    selectedStores: WizardStoreData[];
+    onUpdate: (stores: WizardStoreData[]) => void;
+}
+```
+
+When user toggles a store checkbox, it's added/removed from `selectedStores`. Each selected store shows name/timezone fields.
+
+**Step 2: Commit**
+
+```bash
+git add src/features/settings/presentation/companyDialog/steps/StoreSelectionStep.tsx
+git commit -m "feat: add wizard StoreSelectionStep component"
+```
+
+---
+
+## Task 5: Client-Side Wizard Step Components — Step 3 (Article Format)
+
+**Files:**
+- Create: `src/features/settings/presentation/companyDialog/steps/ArticleFormatStep.tsx`
+
+**Step 1: Create ArticleFormatStep component**
+
+This step:
+- Auto-fetches article format from AIMS on mount (parent passes fetch function)
+- Shows: file extension, delimiter, basic info fields, data fields
+- Fields are editable but pre-populated
+- User can accept or modify
+
+Props:
+```typescript
+interface ArticleFormatStepProps {
+    articleFormat: ArticleFormat | null;
+    loading: boolean;
+    onUpdate: (format: ArticleFormat) => void;
+    onFetch: () => Promise<void>;
+}
+```
+
+Displays `articleBasicInfo` as read-only chips (these are required AIMS fields). Displays `articleData` fields as editable list. Shows `fileExtension` and `delimeter` as TextFields.
+
+**Step 2: Commit**
+
+```bash
+git add src/features/settings/presentation/companyDialog/steps/ArticleFormatStep.tsx
+git commit -m "feat: add wizard ArticleFormatStep component"
+```
+
+---
+
+## Task 6: Client-Side Wizard Step Components — Step 4 (Field Mapping)
+
+**Files:**
+- Create: `src/features/settings/presentation/companyDialog/steps/FieldMappingStep.tsx`
+
+**Step 1: Create FieldMappingStep component**
+
+This step:
+- Pre-populates from article format fields (Step 3 data)
+- Each row: AIMS field name | English display name (TextField) | Visible (Switch)
+- Unique ID field selector (Select from available fields)
+- Conference mapping section (optional): meeting name, meeting time, participants — each a Select from available fields
+
+Props:
+```typescript
+interface FieldMappingStepProps {
+    articleFormat: ArticleFormat | null;
+    fieldMapping: SolumMappingConfig | null;
+    onUpdate: (mapping: SolumMappingConfig) => void;
+}
+```
+
+Auto-generates initial mapping from `articleFormat.articleData` fields if `fieldMapping` is null.
+
+**Step 2: Commit**
+
+```bash
+git add src/features/settings/presentation/companyDialog/steps/FieldMappingStep.tsx
+git commit -m "feat: add wizard FieldMappingStep component"
+```
+
+---
+
+## Task 7: Client-Side Wizard Step Components — Step 5 (Features)
+
+**Files:**
+- Create: `src/features/settings/presentation/companyDialog/steps/FeaturesStep.tsx`
+
+**Step 1: Create FeaturesStep component**
+
+This step:
+- Space type selector at top (Select: office/room/chair/person-tag)
+- Feature cards — each with Switch + description:
+  1. Spaces Management — "Manage office spaces and sync articles from AIMS"
+  2. People Management — "Assign people to spaces. Server manages articles." + mutual exclusivity warning
+  3. Conference Rooms — "Conference room displays. Auto-detects C-prefix articles from AIMS." + mode selector (Full/Simple) + requires field mapping warning
+  4. Labels — "ESL label management and synchronization"
+  5. AIMS Management — "Full AIMS gateway, label, and template management"
+- ALL features disabled by default
+- Mutual exclusivity: enabling Spaces disables People and vice versa (with warning text)
+- Dependency warnings: Conference requires conference field mapping from Step 4
+
+Props:
+```typescript
+interface FeaturesStepProps {
+    features: CompanyFeatures;
+    spaceType: SpaceType;
+    hasConferenceMapping: boolean;  // from Step 4
+    onUpdate: (features: CompanyFeatures, spaceType: SpaceType) => void;
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/features/settings/presentation/companyDialog/steps/FeaturesStep.tsx
+git commit -m "feat: add wizard FeaturesStep component"
+```
+
+---
+
+## Task 8: Client-Side Wizard Step Components — Step 6 (Review)
+
+**Files:**
+- Create: `src/features/settings/presentation/companyDialog/steps/ReviewStep.tsx`
+
+**Step 1: Create ReviewStep component**
+
+Read-only summary of all previous steps:
+- Company info (code, name, location, AIMS connection status)
+- Selected stores (list with names and timezones)
+- Article format summary (extension, delimiter, field count)
+- Field mapping summary (visible field count, unique ID field)
+- Features summary (enabled features with icons)
+
+Each section is clickable to jump back to that step (calls `onGoToStep(n)`).
+
+Props:
+```typescript
+interface ReviewStepProps {
+    formData: WizardFormData;
+    onGoToStep: (step: number) => void;
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/features/settings/presentation/companyDialog/steps/ReviewStep.tsx
+git commit -m "feat: add wizard ReviewStep component"
+```
+
+---
+
+## Task 9: Rewrite CreateCompanyWizard as 6-Step Stepper
+
+**Files:**
+- Rewrite: `src/features/settings/presentation/companyDialog/CreateCompanyWizard.tsx`
+- Create: `src/features/settings/presentation/companyDialog/steps/index.ts` (barrel export)
+
+**Step 1: Create barrel export**
+
+```typescript
+// src/features/settings/presentation/companyDialog/steps/index.ts
+export { ConnectionStep } from './ConnectionStep';
+export { StoreSelectionStep } from './StoreSelectionStep';
+export { ArticleFormatStep } from './ArticleFormatStep';
+export { FieldMappingStep } from './FieldMappingStep';
+export { FeaturesStep } from './FeaturesStep';
+export { ReviewStep } from './ReviewStep';
+```
+
+**Step 2: Define shared wizard types**
+
+Create or add to the wizard file:
+```typescript
+interface WizardStoreData {
+    code: string;
+    name: string;
+    timezone: string;
+    labelCount?: number;
+    gatewayCount?: number;
+    selected: boolean;
+}
+
+interface WizardFormData {
+    // Step 1
+    companyCode: string;
+    companyName: string;
+    location: string;
+    description: string;
+    aimsCluster: string;
+    aimsUsername: string;
+    aimsPassword: string;
+    connectionTested: boolean;
+    // Step 2
+    stores: WizardStoreData[];
+    // Step 3
+    articleFormat: ArticleFormat | null;
+    // Step 4
+    fieldMapping: SolumMappingConfig | null;
+    // Step 5
+    features: CompanyFeatures;
+    spaceType: SpaceType;
+}
+```
+
+**Step 3: Rewrite CreateCompanyWizard**
+
+The wizard:
+- Uses MUI `Stepper` with 6 steps
+- Holds `WizardFormData` state
+- Each step renders the corresponding step component
+- "Next" button validates current step before advancing
+- "Back" button goes to previous step
+- Step 1 requires connection test
+- Step 2 requires at least 1 store selected
+- Step 3 auto-fetches article format on entry
+- Step 6 "Create Company" button submits everything
+
+On submit:
+1. Call `companyService.create()` with the full payload
+2. Show loading spinner
+3. On success: close dialog, show snackbar, refresh company list
+4. On error: show error alert, stay on review step
+
+Responsive:
+- Mobile: `fullScreen` dialog, stepper shows numbers only (no labels)
+- Tablet/Desktop: standard dialog `maxWidth="md"`, full stepper labels
+
+**Step 4: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit --project tsconfig.json 2>&1 | tail -10
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/features/settings/presentation/companyDialog/
+git commit -m "feat: rewrite company creation as 6-step stepper wizard"
+```
+
+---
+
+## Task 10: Update Client companyService for Full Creation Payload
+
+**Files:**
+- Modify: `src/shared/infrastructure/services/companyService.ts`
+
+**Step 1: Extend `create` method**
+
+The `create` method should accept the full payload including `stores`, `articleFormat`, and `fieldMapping`:
+
+```typescript
+async create(data: {
+    code: string;
+    name: string;
+    location?: string;
+    description?: string;
+    aimsConfig?: { baseUrl: string; cluster?: string; username: string; password: string };
+    stores: Array<{ code: string; name?: string; timezone?: string }>;
+    companyFeatures?: CompanyFeatures;
+    spaceType?: SpaceType;
+    articleFormat?: Record<string, unknown>;
+    fieldMapping?: Record<string, unknown>;
+}): Promise<Company> {
+    const response = await this.api.post('/companies', data);
+    return response.data;
+}
+```
+
+**Step 2: Add `fetchArticleFormat` method if not already present**
+
+Check if there's already a method to fetch article format from AIMS during wizard (before company exists). If not, add one that uses the raw AIMS credentials (same as `fetchAimsStores`).
+
+**Step 3: Commit**
+
+```bash
+git add src/shared/infrastructure/services/companyService.ts
+git commit -m "feat: extend companyService.create for full wizard payload"
+```
+
+---
+
+## Task 11: Rewrite EditCompanyTabs to Match Wizard Sections
+
+**Files:**
+- Rewrite: `src/features/settings/presentation/companyDialog/EditCompanyTabs.tsx`
+
+**Step 1: Rewrite with tabbed sections matching wizard steps**
+
+Tabs:
+1. **Basic Info** — Company code (read-only), name, location, description, AIMS connection status
+2. **Stores** — List of existing stores with edit/add capabilities
+3. **Article Format** — Current format display, re-fetch from AIMS button
+4. **Field Mapping** — Current mapping, edit inline
+5. **Features** — Same as wizard Step 5, pre-filled from current settings
+
+Each tab reuses the step components from the wizard (or simplified versions for edit mode).
+
+Pre-fill all fields from `company` prop data. Save changes per-tab (not all at once).
+
+**Step 2: Verify build**
+
+```bash
+npx tsc --noEmit --project tsconfig.json 2>&1 | tail -10
+```
+
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add src/features/settings/presentation/companyDialog/EditCompanyTabs.tsx
+git commit -m "feat: rewrite EditCompanyTabs with wizard-aligned tab sections"
+```
+
+---
+
+## Task 12: Add Translation Keys
+
+**Files:**
+- Modify: `src/locales/en/common.json`
+- Modify: `src/locales/he/common.json`
+
+**Step 1: Add wizard-related keys to BOTH locale files**
+
+English keys to add in the `settings.companies` section:
+```json
+"wizardStep1": "AIMS Connection",
+"wizardStep2": "Select Stores",
+"wizardStep3": "Article Format",
+"wizardStep4": "Field Mapping",
+"wizardStep5": "Features",
+"wizardStep6": "Review & Create",
+"testConnection": "Test Connection",
+"connectionTesting": "Testing...",
+"connectionSuccess": "Connected successfully",
+"connectionFailed": "Connection failed",
+"selectAtLeastOneStore": "Select at least one store",
+"storeName": "Store Name",
+"storeTimezone": "Timezone",
+"labelCount": "Labels",
+"gatewayCount": "Gateways",
+"fetchingArticleFormat": "Fetching article format from AIMS...",
+"articleFormatFetched": "Article format loaded",
+"fileExtension": "File Extension",
+"delimiter": "Delimiter",
+"basicInfoFields": "Basic Info Fields",
+"dataFields": "Data Fields",
+"fieldMappingTitle": "Map AIMS Fields",
+"aimsField": "AIMS Field",
+"displayName": "Display Name",
+"visible": "Visible",
+"uniqueIdField": "Unique ID Field",
+"conferenceMappingTitle": "Conference Mapping (Optional)",
+"meetingNameField": "Meeting Name Field",
+"meetingTimeField": "Meeting Time Field",
+"participantsField": "Participants Field",
+"allFeaturesDisabled": "All features are disabled by default",
+"featureSpaces": "Spaces Management",
+"featureSpacesDesc": "Manage office spaces. Articles synced from AIMS.",
+"featurePeople": "People Management",
+"featurePeopleDesc": "Assign people to spaces. Server manages articles.",
+"featureConference": "Conference Rooms",
+"featureConferenceDesc": "Conference room displays. Auto-detects C-prefix articles.",
+"featureLabels": "Labels",
+"featureLabelsDesc": "ESL label management and synchronization.",
+"featureAims": "AIMS Management",
+"featureAimsDesc": "Full gateway, label, and template management.",
+"mutualExclusiveWarning": "Spaces and People cannot both be enabled",
+"requiresConferenceMapping": "Requires conference field mapping (Step 4)",
+"conferenceModeSimple": "Simple (page flipping)",
+"conferenceModeFull": "Full (real-time updates)",
+"reviewTitle": "Review & Create",
+"reviewCompanyInfo": "Company Info",
+"reviewStores": "Stores",
+"reviewArticleFormat": "Article Format",
+"reviewFieldMapping": "Field Mapping",
+"reviewFeatures": "Features",
+"createCompany": "Create Company",
+"creating": "Creating..."
+```
+
+Hebrew equivalents for all keys.
+
+**Step 2: Commit**
+
+```bash
+git add src/locales/en/common.json src/locales/he/common.json
+git commit -m "feat: add company wizard translation keys (EN + HE)"
+```
+
+---
+
+## Task 13: Server Endpoint for Article Format Fetch (Pre-Company)
+
+**Files:**
+- Modify: `server/src/features/companies/routes.ts`
+- Modify: `server/src/features/companies/controller.ts`
+- Modify: `server/src/features/companies/service.ts`
+
+**Step 1: Add endpoint to fetch article format using raw credentials**
+
+This is needed because during wizard Step 3, the company doesn't exist yet. The endpoint takes raw AIMS credentials (like `fetchAimsStores` does) and fetches the article format.
+
+Route: `POST /api/v1/companies/aims/article-format`
+Auth: Platform admin only (same as fetchAimsStores)
+
+Controller:
+```typescript
+async function fetchArticleFormat(req: Request, res: Response, next: NextFunction) {
+    try {
+        const { baseUrl, cluster, username, password, companyCode } = fetchAimsStoresSchema.parse(req.body);
+        // Use raw credentials to fetch article format from AIMS
+        const format = await companyService.fetchArticleFormat({ baseUrl, cluster, username, password, companyCode });
+        res.json({ data: format });
+    } catch (error) { next(error); }
+}
+```
+
+Service: Creates a temporary SolumConfig, gets token, calls `solumService.fetchArticleFormat(config, token)`.
+
+**Step 2: Verify server compiles**
+
+```bash
+cd server && npx tsc --noEmit 2>&1 | tail -5
+```
+
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add server/src/features/companies/
+git commit -m "feat: add article format fetch endpoint for wizard (raw credentials)"
+```
+
+---
+
+## Task 14: Final Build Verification and PR
+
+**Step 1: Full client build**
+
+```bash
+npm run build 2>&1 | tail -10
+```
+
+Expected: Build succeeds
+
+**Step 2: Full server build**
+
+```bash
+cd server && npx tsc --noEmit 2>&1 | tail -5
+```
+
+Expected: No errors
+
+**Step 3: Push and create PR**
+
+```bash
+git push -u origin feat/company-wizard-redesign
+```
+
+Create PR:
+- Title: `feat: company creation wizard redesign — 6-step stepper`
+- Body: Summary, link to design doc, article safety notes
+- Base: `main`
+
+---
+
+## Files Changed Summary
+
+| File | Action |
+|------|--------|
+| `server/src/shared/utils/featureResolution.ts` | Modify — DEFAULT_COMPANY_FEATURES all-false |
+| `server/src/features/companies/types.ts` | Extend — new schemas for full creation |
+| `server/src/features/companies/service.ts` | Extend — multi-store creation, config save |
+| `server/src/features/companies/controller.ts` | Extend — parse full schema, article format endpoint |
+| `server/src/features/companies/routes.ts` | Add — article format fetch route |
+| `src/shared/infrastructure/services/companyService.ts` | Extend — full creation payload |
+| `src/features/settings/presentation/companyDialog/steps/ConnectionStep.tsx` | CREATE |
+| `src/features/settings/presentation/companyDialog/steps/StoreSelectionStep.tsx` | CREATE |
+| `src/features/settings/presentation/companyDialog/steps/ArticleFormatStep.tsx` | CREATE |
+| `src/features/settings/presentation/companyDialog/steps/FieldMappingStep.tsx` | CREATE |
+| `src/features/settings/presentation/companyDialog/steps/FeaturesStep.tsx` | CREATE |
+| `src/features/settings/presentation/companyDialog/steps/ReviewStep.tsx` | CREATE |
+| `src/features/settings/presentation/companyDialog/steps/index.ts` | CREATE |
+| `src/features/settings/presentation/companyDialog/CreateCompanyWizard.tsx` | Rewrite |
+| `src/features/settings/presentation/companyDialog/EditCompanyTabs.tsx` | Rewrite |
+| `src/locales/en/common.json` | Add ~40 keys |
+| `src/locales/he/common.json` | Add ~40 keys |

--- a/docs/plans/2026-03-03-dashboard-aims-and-company-wizard-design.md
+++ b/docs/plans/2026-03-03-dashboard-aims-and-company-wizard-design.md
@@ -1,0 +1,202 @@
+# Dashboard AIMS Card & Company Creation Wizard — Design Document
+
+**Date:** 2026-03-03
+**Author:** Aviv + Claude
+**Status:** Approved
+
+---
+
+## Overview
+
+Two independent improvements:
+
+1. **AIMS Dashboard Card** — Replace the lightweight 4-stat card with a full overview replica showing all 6 AIMS health categories. Improve overall dashboard unified design across all breakpoints.
+2. **Company Creation Wizard** — Replace the 2-step wizard with a 6-step validated stepper. No features enabled by default. Full article format, field mapping, and multi-store support. Existing companies preserved with new UI.
+
+---
+
+## Subject 1: AIMS Dashboard Card Redesign
+
+### Current State
+
+The `DashboardAimsCard` shows 4 core metrics (total/online gateways, total/online labels) plus optional battery chips. The `AimsOverviewTab` shows 6 detailed cards with comprehensive health metrics from the same `storeSummary` endpoint.
+
+### Target State
+
+A full overview replica embedded in the dashboard card with 6 sub-sections:
+
+| Section | Metrics | Color |
+|---------|---------|-------|
+| Gateway Health | Online/Offline + progress bar | success/error |
+| Label Health | Online/Offline + progress bar | success/error |
+| Update Progress | Updated/In-Progress/Failed | success/warning/error |
+| Battery Health | Good/Low/Critical chips | success/warning/error |
+| Signal Quality | Excellent/Good/Bad | success/info/error |
+| Label Models | Type chips with counts | primary |
+
+### Desktop Layout
+
+- Card spans full width (`xs: 12`) since it's richer than other cards
+- 6 sub-sections arranged in a 2x3 grid using `bgcolor: 'background.default', borderRadius: 2`
+- Each sub-section has a label, progress bar (where applicable), and stat values
+- Header: RouterIcon + "AIMS Management" + "To AIMS →" link
+- All progress bars: `height: 8, borderRadius: 4` with semantic colors
+
+### Mobile Layout
+
+- Tappable header navigates to `/aims-management`
+- Hero number: total gateways
+- Gateway health progress bar
+- 6 rows of `MobileStatTile` pairs covering all categories
+- Battery chips at bottom (existing pattern)
+
+### Data Source Change
+
+Dashboard switches from separate `useGateways()` + `useLabelsOverview()` calls to `useAimsOverview()` which fetches `storeSummary` — a single endpoint with all metrics.
+
+### Dashboard Unified Design
+
+The frontend-design skill will handle polishing all dashboard cards together. The AIMS card sets the standard; other cards get visual alignment. All modes: desktop, mobile, tablet.
+
+---
+
+## Subject 2: Company Creation Wizard Redesign
+
+### Current State
+
+- 2-step wizard: (1) AIMS credentials + test connection, (2) select 1 store + company details + features
+- Default features: `peopleEnabled: true, conferenceEnabled: true, labelsEnabled: true`
+- Article format NOT fetched at creation
+- Field mappings empty on creation
+- Single store only
+
+### Target State
+
+6-step MUI Stepper wizard with full validation at each step. All features disabled by default.
+
+### Step 1: AIMS Connection + Company Info
+
+**Fields:**
+- Company Code (3-20 uppercase, validates uniqueness via debounced API call)
+- Company Name, Location (optional), Description (optional)
+- AIMS Cluster selector (C1 / Common)
+- AIMS Username, Password
+- "Test Connection" button — **required** before proceeding
+
+**Validation:** Connection must succeed. Code must be unique.
+
+### Step 2: Store Selection (Multi-Store)
+
+**Behavior:**
+- Fetches available stores from AIMS via `fetchAimsStores()`
+- Displays as selectable list with checkboxes
+- Each store shows: store code, label count, gateway count (from AIMS)
+- Each selected store gets inline fields: friendly name (optional override), timezone
+- At least 1 store required
+
+**Data:** `{ storeCode, name, timezone, labelCount, gatewayCount }`
+
+### Step 3: Article Format
+
+**Behavior:**
+- Auto-fetches article format from AIMS on step entry
+- Displays: file extension, delimiter, basic info fields, data fields
+- All fields are editable but pre-populated from AIMS response
+- User can accept as-is or modify
+
+**Data:** `ArticleFormat { fileExtension, delimeter, mappingInfo, articleBasicInfo, articleData }`
+
+### Step 4: Field Mapping
+
+**Behavior:**
+- Pre-populated from article format fields (Step 3)
+- Each field row: AIMS field name → English display name → visibility toggle
+- Unique ID field selector (dropdown)
+- Conference mapping section (optional): meeting name, meeting time, participants — each maps to an AIMS field
+
+**Data:** `SolumMappingConfig { uniqueIdField, fields, conferenceMapping }`
+
+### Step 5: Features
+
+**All features disabled by default.** User explicitly enables what they need.
+
+| Feature | Description | Constraints |
+|---------|-------------|-------------|
+| Spaces Management | Manage office spaces and labels | Mutually exclusive with People |
+| People Management | Assign people to spaces | Mutually exclusive with Spaces |
+| Conference Rooms | Conference room displays | Requires conference field mapping (Step 4). Has mode: Full/Simple |
+| Labels | ESL label management and sync | — |
+| AIMS Management | Full AIMS gateway/label/template management | — |
+
+- Space type selector at top (office/room/chair/person-tag)
+- Mutual exclusivity enforced: enabling one disables the other
+- Dependency warnings shown inline (e.g., conference requires mapping)
+
+### Step 6: Review & Create
+
+- Read-only summary of all steps
+- Each section clickable to jump back to that step for editing
+- "Create Company" button with loading state
+- On success: creates company + all stores + saves article format + saves field mapping + sets features
+
+### Existing Company Handling
+
+- **Backward compatibility preserved:** `ALL_FEATURES_ENABLED` fallback for old companies without `settings.companyFeatures` stays in code
+- **Same new UI:** Existing companies (dev + production) get the new editing experience
+- **Edit mode:** Same sections displayed as tabs (not stepper) — each tab corresponds to a wizard step
+- **Pre-filled:** All current settings populated from `company.settings`
+- **No data loss:** Current features, article format, and field mappings preserved
+
+### Responsive Design
+
+| Breakpoint | Dialog | Stepper | Fields |
+|------------|--------|---------|--------|
+| Mobile (xs) | `fullScreen` | Step numbers only (labels hidden) | Stacked, full-width |
+| Tablet (sm) | Standard dialog | Full stepper visible | 2-column where appropriate |
+| Desktop (md+) | `maxWidth: 'md'` | Full stepper | Side-by-side fields |
+
+### Server Changes
+
+- Company creation endpoint accepts full payload: company + stores[] + articleFormat + fieldMapping + features
+- New endpoint or extended existing: `POST /api/v1/companies` accepts nested store creation
+- Article format fetch endpoint already exists: `GET /settings/company/:companyId/article-format`
+- Field mapping save endpoint already exists: `PUT /settings/company/:companyId/field-mappings`
+
+---
+
+## Files Affected
+
+### Subject 1: AIMS Dashboard Card
+| File | Action |
+|------|--------|
+| `src/features/dashboard/components/DashboardAimsCard.tsx` | Rewrite — full overview replica |
+| `src/features/dashboard/DashboardPage.tsx` | Update data fetching (useAimsOverview), card grid sizing |
+| `src/features/dashboard/components/MobileStatTile.tsx` | Minor — may need additional color support |
+| `src/features/dashboard/components/*.tsx` | Polish — unified design alignment |
+| `src/locales/en/common.json` | Add dashboard AIMS keys |
+| `src/locales/he/common.json` | Add dashboard AIMS keys |
+
+### Subject 2: Company Wizard
+| File | Action |
+|------|--------|
+| `src/features/settings/presentation/companyDialog/CreateCompanyWizard.tsx` | Rewrite — 6-step stepper |
+| `src/features/settings/presentation/companyDialog/EditCompanyTabs.tsx` | Rewrite — match wizard sections as tabs |
+| `src/features/settings/presentation/companyDialog/steps/` | CREATE — step components (6 files) |
+| `src/features/settings/presentation/StoreDialog.tsx` | Update — align with new store creation flow |
+| `server/src/features/companies/service.ts` | Extend — accept full creation payload |
+| `server/src/features/companies/types.ts` | Extend — new Zod schemas |
+| `server/src/shared/utils/featureResolution.ts` | Update — DEFAULT_COMPANY_FEATURES all false |
+| `src/locales/en/common.json` | Add wizard step keys |
+| `src/locales/he/common.json` | Add wizard step keys |
+
+---
+
+## Verification
+
+1. `npm run build` — client builds cleanly
+2. `cd server && npx tsc --noEmit` — server compiles
+3. Dashboard: AIMS card shows all 6 sections, responsive on mobile/tablet/desktop
+4. Dashboard: other cards maintain visual consistency
+5. Create Company: full 6-step wizard works end-to-end
+6. Edit Company: existing companies show all tabs with current data preserved
+7. Existing dev/production companies: features unchanged after code changes

--- a/server/src/features/conference/controller.ts
+++ b/server/src/features/conference/controller.ts
@@ -1,6 +1,6 @@
 import type { Request, Response, NextFunction } from 'express';
 import { conferenceService } from './service.js';
-import { createRoomSchema, updateRoomSchema, toggleMeetingSchema } from './types.js';
+import { createRoomSchema, updateRoomSchema, toggleMeetingSchema, flipPageSchema } from './types.js';
 import type { ConferenceUserContext } from './types.js';
 import { notFound, badRequest, conflict, forbidden } from '../../shared/middleware/index.js';
 import { sseManager } from '../../shared/infrastructure/sse/SseManager.js';
@@ -188,12 +188,48 @@ export const conferenceController = {
     },
 
     /**
-     * POST /conference/:id/flip-page - Manually flip ESL page
+     * GET /conference/label-pages - Get current page for all conference room labels
+     */
+    async getLabelPages(req: Request, res: Response, next: NextFunction) {
+        try {
+            const userContext = getUserContext(req);
+            const storeId = req.query.storeId as string;
+            if (!storeId) {
+                return next(badRequest('storeId query parameter is required'));
+            }
+            const pageMap = await conferenceService.getLabelPages(userContext, storeId);
+            res.json(pageMap);
+        } catch (error) {
+            next(mapServiceError(error));
+        }
+    },
+
+    /**
+     * POST /conference/:id/flip-page - Flip ESL page directly via AIMS
+     * Body: { page: 1-7 } (1=Available, 2=Busy)
      */
     async flipPage(req: Request, res: Response, next: NextFunction) {
         try {
             const userContext = getUserContext(req);
-            const result = await conferenceService.flipPage(userContext, req.params.id as string);
+            const { page } = flipPageSchema.parse(req.body);
+            const result = await conferenceService.flipPage(userContext, req.params.id as string, page);
+
+            // Broadcast page flip to all clients in this store
+            const room = await conferenceService.getById(userContext, req.params.id as string);
+            const sseClientId = req.headers['x-sse-client-id'] as string | undefined;
+            sseManager.broadcastToStore(room.storeId, {
+                type: 'conference:page-flip',
+                payload: {
+                    action: 'page-flip',
+                    roomId: room.externalId,
+                    serverId: room.id,
+                    page,
+                    labelCodes: result.labelCodes,
+                    userName: req.user?.email || 'Unknown',
+                },
+                excludeClientId: sseClientId,
+            });
+
             res.json(result);
         } catch (error) {
             next(mapServiceError(error));

--- a/server/src/features/conference/routes.ts
+++ b/server/src/features/conference/routes.ts
@@ -9,6 +9,7 @@ router.use(authenticate);
 router.use(restrictAppViewer());
 
 // Conference room routes
+router.get('/label-pages', requirePermission('conference', 'read'), conferenceController.getLabelPages);
 router.get('/', requirePermission('conference', 'read'), conferenceController.list);
 router.get('/:id', requirePermission('conference', 'read'), conferenceController.getById);
 router.post('/', requirePermission('conference', 'create'), conferenceController.create);

--- a/server/src/features/conference/service.ts
+++ b/server/src/features/conference/service.ts
@@ -1,5 +1,7 @@
 import { conferenceRepository } from './repository.js';
 import { syncQueueService } from '../../shared/infrastructure/services/syncQueueService.js';
+import { aimsGateway } from '../../shared/infrastructure/services/aimsGateway.js';
+import { appLogger } from '../../shared/infrastructure/services/appLogger.js';
 import type {
     ConferenceUserContext,
     ConferenceRoomStats,
@@ -147,26 +149,77 @@ export const conferenceService = {
     },
 
     /**
-     * Request ESL page flip for a room
+     * Get current page for all conference room labels from AIMS
+     * Returns map of labelCode → currentPage
      */
-    async flipPage(userContext: ConferenceUserContext, roomId: string) {
+    async getLabelPages(userContext: ConferenceUserContext, storeId: string): Promise<Record<string, number>> {
+        validateStoreAccess(storeId, userContext);
+
+        // Get all conference rooms for this store
+        const storeIds = getEffectiveStoreIds(userContext);
+        const rooms = await conferenceRepository.list(storeIds, storeId);
+
+        // Collect all label codes
+        const labelCodes: string[] = [];
+        for (const room of rooms) {
+            if (room.labelCode) labelCodes.push(room.labelCode);
+            if (room.assignedLabels?.length) {
+                for (const lc of room.assignedLabels) {
+                    if (!labelCodes.includes(lc)) labelCodes.push(lc);
+                }
+            }
+        }
+
+        if (labelCodes.length === 0) return {};
+
+        // Fetch all labels from AIMS for this store (they include currentPage)
+        const labels = await aimsGateway.fetchLabels(storeId);
+        const pageMap: Record<string, number> = {};
+        for (const label of labels) {
+            if (labelCodes.includes(label.labelCode)) {
+                pageMap[label.labelCode] = (label as any).currentPage ?? 1;
+            }
+        }
+
+        return pageMap;
+    },
+
+    /**
+     * Flip ESL page for a room — direct AIMS API call (not queued)
+     * Supports multiple labels per room (all get same page)
+     * Page 1 = Available, Page 2 = Busy
+     */
+    async flipPage(userContext: ConferenceUserContext, roomId: string, page: number) {
         const storeIds = getEffectiveStoreIds(userContext);
         const existing = await conferenceRepository.getByIdWithAccess(roomId, storeIds);
         if (!existing) {
             throw 'NOT_FOUND';
         }
 
-        if (!existing.labelCode) {
+        // Collect all label codes for this room
+        const labelCodes: string[] = [];
+        if (existing.labelCode) labelCodes.push(existing.labelCode);
+        if (existing.assignedLabels?.length) {
+            for (const lc of existing.assignedLabels) {
+                if (!labelCodes.includes(lc)) labelCodes.push(lc);
+            }
+        }
+
+        if (labelCodes.length === 0) {
             throw 'NO_LABEL_ASSIGNED';
         }
 
-        // Queue job to flip ESL page in AIMS
-        await syncQueueService.queueUpdate(existing.storeId, 'conference', existing.id, { flipPage: true });
+        // Direct AIMS API call — requires 200 for success
+        appLogger.info('ConferenceService', `Flipping page for room ${roomId}`, { labelCodes, page });
+        const result = await aimsGateway.changeLabelPage(existing.storeId, labelCodes, page);
+        appLogger.info('ConferenceService', `Page flip successful for room ${roomId}`, { labelCodes, page });
 
         return {
-            message: 'Page flip requested',
+            message: 'Page flip successful',
             roomId: existing.id,
-            labelCode: existing.labelCode,
+            labelCodes,
+            page,
+            aimsResponse: result,
         };
     },
 };

--- a/server/src/features/conference/types.ts
+++ b/server/src/features/conference/types.ts
@@ -33,6 +33,10 @@ export const toggleMeetingSchema = z.object({
     participants: z.array(z.string()).optional(),
 });
 
+export const flipPageSchema = z.object({
+    page: z.number().int().min(1).max(7),
+});
+
 // ============================================================================
 // DTOs
 // ============================================================================
@@ -40,6 +44,7 @@ export const toggleMeetingSchema = z.object({
 export type CreateRoomDTO = z.infer<typeof createRoomSchema>;
 export type UpdateRoomDTO = z.infer<typeof updateRoomSchema>;
 export type ToggleMeetingDTO = z.infer<typeof toggleMeetingSchema>;
+export type FlipPageDTO = z.infer<typeof flipPageSchema>;
 
 // ============================================================================
 // Interfaces

--- a/server/src/shared/infrastructure/services/aimsGateway.ts
+++ b/server/src/shared/infrastructure/services/aimsGateway.ts
@@ -1000,6 +1000,12 @@ export class AIMSGateway {
     async fetchUnassignedWhitelist(storeId: string, params?: { page?: number; size?: number; labelCode?: string; labelModel?: string; sort?: string }) {
         return this.withTokenRetry(storeId, (token, config) => solumService.fetchUnassignedWhitelist(config, token, params));
     }
+
+    // ─── Conference Page Flip ──────────────────────────────────────────────
+
+    async changeLabelPage(storeId: string, labelCodes: string[], page: number) {
+        return this.withTokenRetry(storeId, (token, config) => solumService.changeLabelPage(config, token, labelCodes, page));
+    }
 }
 
 // Singleton instance

--- a/server/src/shared/infrastructure/services/solumService.ts
+++ b/server/src/shared/infrastructure/services/solumService.ts
@@ -511,16 +511,20 @@ export class SolumService {
     }
 
     /**
-     * Change label page/template
+     * Change label page (AIMS API: POST /api/v2/common/labels/page)
+     * Body: { pageChangeList: [{ labelCode, page }] }
+     * Page values: 1-7 (1=Available, 2=Busy for conference simple mode)
      */
-    async changeLabelPage(config: SolumConfig, token: string, labelCode: string, page: number): Promise<AimsApiResponse> {
+    async changeLabelPage(config: SolumConfig, token: string, labelCodes: string[], page: number): Promise<AimsApiResponse> {
         if (!config.storeCode) throw new Error('Store code required');
 
-        const url = this.buildUrl(config, `/common/api/v2/common/labels/changePage?company=${config.companyName}&store=${config.storeCode}`);
+        const url = this.buildUrl(config, `/common/api/v2/common/labels/page?company=${config.companyName}&store=${config.storeCode}`);
+
+        const pageChangeList = labelCodes.map(labelCode => ({ labelCode, page }));
 
         return this.withRetry('changeLabelPage', async () => {
             try {
-                const response = await this.client.post(url, { labelCode, page }, {
+                const response = await this.client.post(url, { pageChangeList }, {
                     headers: { 'Authorization': `Bearer ${token}` }
                 });
                 return response.data;

--- a/server/src/shared/infrastructure/sse/SseManager.ts
+++ b/server/src/shared/infrastructure/sse/SseManager.ts
@@ -24,7 +24,7 @@ export interface SseClient {
 }
 
 export interface StoreEvent {
-    type: 'people:changed' | 'list:loaded' | 'list:freed' | 'list:updated' | 'conference:changed';
+    type: 'people:changed' | 'list:loaded' | 'list:freed' | 'list:updated' | 'conference:changed' | 'conference:page-flip';
     payload: Record<string, unknown>;
     /** If set, this client will NOT receive the event (originator) */
     excludeClientId?: string;

--- a/src/features/conference/application/hooks/useConferenceAIMS.ts
+++ b/src/features/conference/application/hooks/useConferenceAIMS.ts
@@ -24,7 +24,7 @@ interface UseConferenceAIMSResult {
     pushToAIMS: (room: ConferenceRoom) => Promise<void>;
     deleteFromAIMS: (id: string) => Promise<void>;
     fetchFromAIMS: () => Promise<ConferenceRoom[]>;
-    flipLabelPage: (labelCode: string, currentPage: number) => Promise<void>;
+    flipLabelPage: (labelCodes: string[], targetPage: number) => Promise<void>;
     isAIMSConfigured: boolean;
 }
 
@@ -128,26 +128,26 @@ export function useConferenceAIMS({
 
     /**
      * Flip label page (for SoluM simple conference mode)
+     * Page 1 = Available, Page 2 = Busy
+     * Supports multiple labels per room (all get same page)
      */
     const flipLabelPage = useCallback(
-        async (labelCode: string, currentPage: number): Promise<void> => {
+        async (labelCodes: string[], targetPage: number): Promise<void> => {
             if (!solumConfig || !solumToken) {
                 throw new Error('SoluM configuration or token not available');
             }
 
-            logger.info('ConferenceAIMS', 'Flipping label page', { labelCode, currentPage });
-
-            const newPage = currentPage === 0 ? 1 : 0;
+            logger.info('ConferenceAIMS', 'Flipping label page', { labelCodes, targetPage });
 
             await solumService.updateLabelPage(
                 solumConfig,
                 solumConfig.storeNumber,
                 solumToken,
-                labelCode,
-                newPage
+                labelCodes,
+                targetPage
             );
 
-            logger.info('ConferenceAIMS', 'Label page flipped', { labelCode, newPage });
+            logger.info('ConferenceAIMS', 'Label page flipped', { labelCodes, targetPage });
         },
         [solumConfig, solumToken]
     );

--- a/src/features/conference/application/useConferenceController.ts
+++ b/src/features/conference/application/useConferenceController.ts
@@ -255,10 +255,12 @@ export function useConferenceController({
 
     /**
      * Flip label page (direct AIMS operation for ESL labels)
+     * Page 1 = Available, Page 2 = Busy
+     * Supports multiple labels per room
      */
     const flipLabelPage = useCallback(
-        async (labelCode: string, currentPage: number): Promise<void> => {
-            await flipLabelPageInternal(labelCode, currentPage);
+        async (labelCodes: string[], targetPage: number): Promise<void> => {
+            await flipLabelPageInternal(labelCodes, targetPage);
         },
         [flipLabelPageInternal]
     );

--- a/src/features/conference/infrastructure/conferenceApi.ts
+++ b/src/features/conference/infrastructure/conferenceApi.ts
@@ -135,11 +135,24 @@ export const conferenceApi = {
     },
 
     /**
-     * Flip ESL page manually
+     * Get current page for all conference room labels from AIMS
+     * Returns map of labelCode → currentPage
      */
-    flipPage: async (id: string): Promise<{ message: string; roomId: string; labelCode: string }> => {
-        const response = await api.post<{ message: string; roomId: string; labelCode: string }>(
-            `/conference/${id}/flip-page`
+    getLabelPages: async (storeId: string): Promise<Record<string, number>> => {
+        const response = await api.get<Record<string, number>>('/conference/label-pages', {
+            params: { storeId },
+        });
+        return response.data;
+    },
+
+    /**
+     * Flip ESL page via server → AIMS API
+     * Page 1 = Available, Page 2 = Busy
+     */
+    flipPage: async (id: string, page: number): Promise<{ message: string; roomId: string; labelCodes: string[]; page: number }> => {
+        const response = await api.post<{ message: string; roomId: string; labelCodes: string[]; page: number }>(
+            `/conference/${id}/flip-page`,
+            { page }
         );
         return response.data;
     },

--- a/src/features/conference/presentation/ConferencePage.tsx
+++ b/src/features/conference/presentation/ConferencePage.tsx
@@ -21,6 +21,10 @@ import {
     Fab,
     Badge,
     Collapse,
+    Radio,
+    RadioGroup,
+    FormControlLabel,
+    CircularProgress,
     useMediaQuery,
     useTheme,
 } from '@mui/material';
@@ -33,7 +37,7 @@ import PeopleIcon from '@mui/icons-material/People';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import FilterListIcon from '@mui/icons-material/FilterList';
 import { ConferenceIcon } from '../../../components/icons/ConferenceIcon';
-import { useState, useEffect, useMemo, useCallback, lazy, Suspense } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef, lazy, Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDebounce } from '@shared/presentation/hooks/useDebounce';
 import { useConferenceController } from '../application/useConferenceController';
@@ -44,6 +48,7 @@ import { useAuthContext } from '@features/auth/application/useAuthContext';
 import type { ConferenceRoom } from '@shared/domain/types';
 import { useConfirmDialog } from '@shared/presentation/hooks/useConfirmDialog';
 import { useStoreEvents } from '@shared/presentation/hooks/useStoreEvents';
+import { conferenceApi } from '../infrastructure/conferenceApi';
 
 // Lazy load dialog - not needed on initial render
 const ConferenceRoomDialog = lazy(() => import('./ConferenceRoomDialog').then(m => ({ default: m.ConferenceRoomDialog })));
@@ -90,10 +95,101 @@ export function ConferencePage() {
     const [searchOpen, setSearchOpen] = useState(false);
     const [expandedCardId, setExpandedCardId] = useState<string | null>(null);
 
+    // Simple conference mode state
+    const { activeStoreEffectiveFeatures } = useAuthContext();
+    const isSimpleMode = activeStoreEffectiveFeatures?.simpleConferenceMode ?? false;
+    const [labelPages, setLabelPages] = useState<Record<string, number>>({});
+    const [labelPagesLoading, setLabelPagesLoading] = useState(false);
+    const [flippingRoomId, setFlippingRoomId] = useState<string | null>(null);
+    const [flipSnackbar, setFlipSnackbar] = useState<{ message: string; severity: 'success' | 'error' } | null>(null);
+    const labelPagesFetchedRef = useRef(false);
+
+    // Fetch label pages from AIMS when in simple mode
+    useEffect(() => {
+        if (!isSimpleMode || !isAppReady || !activeStoreId || labelPagesFetchedRef.current) return;
+        labelPagesFetchedRef.current = true;
+        setLabelPagesLoading(true);
+        conferenceApi.getLabelPages(activeStoreId)
+            .then(pages => setLabelPages(pages))
+            .catch(() => {})
+            .finally(() => setLabelPagesLoading(false));
+    }, [isSimpleMode, isAppReady, activeStoreId]);
+
+    // Reset label pages fetch ref when store changes
+    useEffect(() => {
+        labelPagesFetchedRef.current = false;
+    }, [activeStoreId]);
+
+    // Get room page status: check all labels for this room, return the dominant page
+    const getRoomPage = useCallback((room: ConferenceRoom): number => {
+        const codes: string[] = [];
+        if (room.labelCode) codes.push(room.labelCode);
+        if (room.assignedLabels?.length) {
+            for (const lc of room.assignedLabels) {
+                if (!codes.includes(lc)) codes.push(lc);
+            }
+        }
+        if (codes.length === 0) return 1; // Default: available
+        // Use the first label's page as the room's status
+        for (const code of codes) {
+            if (labelPages[code] !== undefined) return labelPages[code];
+        }
+        return 1; // Default: available
+    }, [labelPages]);
+
+    // Handle page flip for simple mode
+    const handleFlipPage = useCallback(async (room: ConferenceRoom, targetPage: number) => {
+        const serverId = room.serverId || room.id;
+        setFlippingRoomId(room.id);
+        try {
+            const result = await conferenceApi.flipPage(serverId, targetPage);
+            // Update local label pages state
+            if (result.labelCodes) {
+                setLabelPages(prev => {
+                    const next = { ...prev };
+                    for (const lc of result.labelCodes) {
+                        next[lc] = targetPage;
+                    }
+                    return next;
+                });
+            }
+            setFlipSnackbar({ message: t('conference.flipPageSuccess'), severity: 'success' });
+        } catch {
+            setFlipSnackbar({ message: t('conference.flipPageFailed'), severity: 'error' });
+        } finally {
+            setFlippingRoomId(null);
+        }
+    }, [t]);
+
     // SSE real-time sync — alert when other users modify conference rooms
     useStoreEvents({
         onConferenceChanged: (event) => {
             console.log('[ConferencePage] SSE event received:', event);
+
+            // Handle page-flip events from other users
+            if (event.action === 'page-flip') {
+                const { labelCodes, page } = event as any;
+                if (labelCodes && page !== undefined) {
+                    setLabelPages(prev => {
+                        const next = { ...prev };
+                        for (const lc of labelCodes) {
+                            next[lc] = page;
+                        }
+                        return next;
+                    });
+                }
+                setSseAlert({
+                    message: t('conference.roomChangedByOther', {
+                        defaultValue: '{{user}} {{action}} conference room {{roomId}}',
+                        user: event.userName || 'Another user',
+                        action: page === 2 ? 'set as occupied' : 'set as available',
+                        roomId: event.roomId || 'Unknown',
+                    }),
+                    severity: 'info',
+                });
+                return;
+            }
+
             const actionText = event.action === 'create' ? 'added' :
                               event.action === 'update' ? 'updated' :
                               event.action === 'delete' ? 'deleted' :
@@ -211,6 +307,181 @@ export function ConferencePage() {
         '&:hover': { boxShadow: '0px 0px 1px 1px #6666663b' }
     }), []);
 
+    // ─── Simple Conference Mode Rendering ─────────────────────────────────
+    if (isSimpleMode) {
+        return (
+            <Box>
+                <Box sx={{ mb: 3 }}>
+                    <Typography variant="h4" sx={{ fontWeight: 500, mb: 0.5, fontSize: { xs: '1.25rem', sm: '2rem' } }}>
+                        {t('conference.title')}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                        {t('conference.manage')}
+                    </Typography>
+                </Box>
+
+                {/* Stats */}
+                <Stack direction="row" gap={2} sx={{ mb: 3 }}>
+                    <Typography variant="body2" fontWeight={600}>
+                        {conferenceController.conferenceRooms.length} {t('conference.totalRooms')}
+                    </Typography>
+                </Stack>
+
+                {conferenceController.isFetching ? (
+                    <Stack gap={2}>
+                        {Array.from({ length: 4 }).map((_, i) => (
+                            <Skeleton key={i} variant="rounded" height={64} />
+                        ))}
+                    </Stack>
+                ) : labelPagesLoading ? (
+                    <Stack alignItems="center" gap={2} sx={{ py: 4 }}>
+                        <CircularProgress size={32} />
+                        <Typography variant="body2" color="text.secondary">
+                            {t('conference.loadingPages')}
+                        </Typography>
+                    </Stack>
+                ) : conferenceController.conferenceRooms.length === 0 ? (
+                    <Card>
+                        <CardContent sx={{ py: 8, textAlign: 'center' }}>
+                            <ConferenceIcon sx={{ fontSize: 64, color: 'text.secondary', mb: 2 }} />
+                            <Typography variant="h6">{t('conference.noRoomsYet')}</Typography>
+                        </CardContent>
+                    </Card>
+                ) : (
+                    <Stack gap={1}>
+                        {filteredRooms.map((room) => {
+                            const roomPage = getRoomPage(room);
+                            const isFlipping = flippingRoomId === room.id;
+                            const hasLabels = !!(room.labelCode || (room.assignedLabels && room.assignedLabels.length > 0));
+                            const labelCount = new Set([
+                                ...(room.labelCode ? [room.labelCode] : []),
+                                ...(room.assignedLabels || []),
+                            ]).size;
+
+                            return (
+                                <Card
+                                    key={room.id}
+                                    variant="outlined"
+                                    sx={{
+                                        transition: 'background-color 0.2s',
+                                        bgcolor: roomPage === 2 ? 'error.50' : 'transparent',
+                                        borderColor: roomPage === 2 ? 'error.main' : 'divider',
+                                    }}
+                                >
+                                    <CardContent sx={{ py: 1.5, px: 2, '&:last-child': { pb: 1.5 } }}>
+                                        <Stack
+                                            direction="row"
+                                            alignItems="center"
+                                            justifyContent="space-between"
+                                            gap={2}
+                                        >
+                                            {/* Room info */}
+                                            <Stack direction="row" alignItems="center" gap={1.5} sx={{ minWidth: 0, flex: 1 }}>
+                                                <Typography
+                                                    variant="body2"
+                                                    fontWeight={700}
+                                                    dir="ltr"
+                                                    sx={{ color: 'text.secondary', whiteSpace: 'nowrap' }}
+                                                >
+                                                    {room.id}
+                                                </Typography>
+                                                <Typography variant="body1" fontWeight={500} noWrap>
+                                                    {room.roomName || room.data?.roomName || room.id}
+                                                </Typography>
+                                                {hasLabels && labelCount > 1 && (
+                                                    <Chip
+                                                        label={`${labelCount} ${t('conference.labels')}`}
+                                                        size="small"
+                                                        variant="outlined"
+                                                        sx={{ height: 20, fontSize: '0.7rem' }}
+                                                    />
+                                                )}
+                                            </Stack>
+
+                                            {/* Status radio */}
+                                            {hasLabels ? (
+                                                <RadioGroup
+                                                    row
+                                                    value={String(roomPage)}
+                                                    onChange={(_e, value) => {
+                                                        if (!isFlipping && canEdit) {
+                                                            handleFlipPage(room, Number(value));
+                                                        }
+                                                    }}
+                                                >
+                                                    <FormControlLabel
+                                                        value="1"
+                                                        disabled={isFlipping || !canEdit}
+                                                        control={<Radio size="small" color="success" />}
+                                                        label={
+                                                            <Typography variant="body2" sx={{ fontSize: '0.85rem' }}>
+                                                                {t('conference.available')}
+                                                            </Typography>
+                                                        }
+                                                        sx={{ mr: 1 }}
+                                                    />
+                                                    <FormControlLabel
+                                                        value="2"
+                                                        disabled={isFlipping || !canEdit}
+                                                        control={<Radio size="small" color="error" />}
+                                                        label={
+                                                            <Typography variant="body2" sx={{ fontSize: '0.85rem' }}>
+                                                                {t('conference.inMeeting')}
+                                                            </Typography>
+                                                        }
+                                                    />
+                                                    {isFlipping && <CircularProgress size={20} sx={{ ml: 1 }} />}
+                                                </RadioGroup>
+                                            ) : (
+                                                <Typography variant="caption" color="text.secondary">
+                                                    {t('conference.noScheduledMeetings')}
+                                                </Typography>
+                                            )}
+                                        </Stack>
+                                    </CardContent>
+                                </Card>
+                            );
+                        })}
+                    </Stack>
+                )}
+
+                {/* Page flip snackbar */}
+                <Snackbar
+                    open={!!flipSnackbar}
+                    autoHideDuration={4000}
+                    onClose={() => setFlipSnackbar(null)}
+                    anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+                >
+                    <Alert
+                        onClose={() => setFlipSnackbar(null)}
+                        severity={flipSnackbar?.severity || 'info'}
+                        sx={{ width: '100%' }}
+                    >
+                        {flipSnackbar?.message}
+                    </Alert>
+                </Snackbar>
+
+                {/* SSE Alert Snackbar */}
+                <Snackbar
+                    open={!!sseAlert}
+                    autoHideDuration={6000}
+                    onClose={() => setSseAlert(null)}
+                    anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                >
+                    <Alert
+                        onClose={() => setSseAlert(null)}
+                        severity={sseAlert?.severity || 'info'}
+                        sx={{ width: '100%' }}
+                    >
+                        {sseAlert?.message}
+                    </Alert>
+                </Snackbar>
+                <ConfirmDialog />
+            </Box>
+        );
+    }
+
+    // ─── Full Conference Mode Rendering ────────────────────────────────────
     return (
         <Box>
             {/* Header Section */}

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -441,7 +441,13 @@
         "startTime": "Start Time",
         "endTime": "End Time",
         "participantsHelper": "Comma-separated list of participants",
-        "preview": "Preview:"
+        "preview": "Preview:",
+        "roomStatus": "Room Status",
+        "flipPageFailed": "Failed to change room status",
+        "flipPageSuccess": "Room status changed successfully",
+        "inMeeting": "In a Meeting",
+        "loadingPages": "Loading room status...",
+        "labels": "Labels"
     },
     "sync": {
         "title": "Synchronization",

--- a/src/locales/he/common.json
+++ b/src/locales/he/common.json
@@ -452,7 +452,13 @@
         "startTime": "זמן התחלה",
         "endTime": "זמן סיום",
         "participantsHelper": "רשימת משתתפים מופרדת בפסיקים",
-        "preview": "תצוגה מקדימה:"
+        "preview": "תצוגה מקדימה:",
+        "roomStatus": "סטטוס חדר",
+        "flipPageFailed": "שינוי סטטוס החדר נכשל",
+        "flipPageSuccess": "סטטוס החדר שונה בהצלחה",
+        "inMeeting": "בפגישה",
+        "loadingPages": "טוען סטטוס חדרים...",
+        "labels": "תגיות"
     },
     "sync": {
         "title": "סינכרון",

--- a/src/shared/infrastructure/services/solum/labelsService.ts
+++ b/src/shared/infrastructure/services/solum/labelsService.ts
@@ -313,31 +313,30 @@ export async function unlinkLabel(
 }
 
 /**
- * Update label page (for simple conference mode)
- * @param config - SoluM configuration
- * @param storeId - Store number
- * @param token - Access token
- * @param labelCode - Label code
- * @param page - Page number (0 or 1)
+ * Update label page (AIMS API: POST /api/v2/common/labels/page)
+ * Body: { pageChangeList: [{ labelCode, page }] }
+ * Page values: 1-7 (1=Available, 2=Busy for conference simple mode)
  */
 export async function updateLabelPage(
     config: SolumConfig,
     storeId: string,
     token: string,
-    labelCode: string,
+    labelCodes: string[],
     page: number
 ): Promise<void> {
-    logger.info('SolumLabelsService', 'Updating label page', { labelCode, page });
+    logger.info('SolumLabelsService', 'Updating label page', { labelCodes, page });
 
-    const url = buildUrl(config, `/common/api/v2/common/labels/changePage?company=${config.companyName}&store=${storeId}`);
+    const url = buildUrl(config, `/common/api/v2/common/labels/page?company=${config.companyName}&store=${storeId}`);
+
+    const pageChangeList = labelCodes.map(labelCode => ({ labelCode, page }));
 
     const response = await fetch(url, {
-        method: 'PUT',
+        method: 'POST',
         headers: {
             'Authorization': `Bearer ${token}`,
             'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ page }),
+        body: JSON.stringify({ pageChangeList }),
     });
 
     if (!response.ok) {

--- a/src/shared/infrastructure/services/storeEventsService.ts
+++ b/src/shared/infrastructure/services/storeEventsService.ts
@@ -11,13 +11,13 @@ import { tokenManager } from './apiClient';
 const isDev = import.meta.env.DEV;
 const API_BASE_URL = isDev ? 'http://127.0.0.1:3001/api/v1' : (import.meta.env.VITE_API_BASE_URL || `${import.meta.env.BASE_URL}api/v1`);
 
-export type StoreEventType = 'connected' | 'people:changed' | 'list:loaded' | 'list:freed' | 'list:updated' | 'conference:changed';
+export type StoreEventType = 'connected' | 'people:changed' | 'list:loaded' | 'list:freed' | 'list:updated' | 'conference:changed' | 'conference:page-flip';
 
 export interface StoreEvent {
     type: StoreEventType;
     timestamp: string;
     // people:changed, conference:changed
-    action?: 'create' | 'delete' | 'assign' | 'unassign' | 'update' | 'toggle';
+    action?: 'create' | 'delete' | 'assign' | 'unassign' | 'update' | 'toggle' | 'page-flip';
     personId?: string;
     spaceId?: string;
     // list:loaded

--- a/src/shared/presentation/hooks/useStoreEvents.ts
+++ b/src/shared/presentation/hooks/useStoreEvents.ts
@@ -93,6 +93,7 @@ export function useStoreEvents(options: UseStoreEventsOptions = {}) {
                 break;
 
             case 'conference:changed':
+            case 'conference:page-flip':
                 logger.info('StoreEvents', 'Conference changed by another user', {
                     action: event.action,
                     roomId: event.roomId,


### PR DESCRIPTION
## Summary
- Fix AIMS page flip endpoint from `/changePage` to `/page` with correct POST body format `{pageChangeList: [{labelCode, page}]}`
- Add simple conference mode UI: room ID + name + Available/Busy radio buttons, controlled by `simpleConferenceMode` feature flag
- Direct AIMS API call (not sync queue) with 200 confirmation, SSE broadcast for live updates, multi-label room support

Closes #119

## Test plan
- [ ] Enable `simpleConferenceMode` in store features
- [ ] Verify conference page shows simplified Available/Busy radio buttons
- [ ] Flip a room status and confirm AIMS label page changes (check label currentPage)
- [ ] Verify other users see the change in real-time via SSE
- [ ] Test room with multiple assigned labels — all should flip together
- [ ] Test with `simpleConferenceMode` disabled — full conference mode unchanged
- [ ] Verify Hebrew RTL layout works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)