### PR TITLE
fix: logo leak between companies/stores and people card layout

### DIFF
--- a/src/features/people/presentation/PeopleManagerView.tsx
+++ b/src/features/people/presentation/PeopleManagerView.tsx
@@ -1,6 +1,7 @@
 import { logger } from '@shared/infrastructure/services/logger';
-import { Box, Snackbar, Alert, Fab, useMediaQuery, useTheme } from '@mui/material';
+import { Box, Snackbar, Alert, Fab, Button, useMediaQuery, useTheme } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
+import CancelIcon from '@mui/icons-material/Cancel';
 import { useState, useMemo, useCallback, useEffect, useDeferredValue, lazy, Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDebounce } from '@shared/presentation/hooks/useDebounce';
@@ -505,9 +506,6 @@ export function PeopleManagerView() {
                 onSearchChange={setSearchQuery}
                 assignmentFilter={assignmentFilter}
                 onAssignmentFilterChange={setAssignmentFilter}
-                canEdit={canEdit}
-                onCancelAllAssignments={handleCancelAllAssignments}
-                assignedCount={assignedCount}
             />
 
             {/* Bulk Actions */}
@@ -540,6 +538,20 @@ export function PeopleManagerView() {
                 onUnassignSpace={handleUnassignSpace}
             />
 
+
+            {/* Mobile: Unassign All button at the bottom of the page */}
+            {isMobile && canEdit && assignedCount > 0 && (
+                <Box sx={{ mt: 2, mb: 10, display: 'flex', justifyContent: 'flex-start' }}>
+                    <Button
+                        variant="text"
+                        color="error"
+                        startIcon={<CancelIcon />}
+                        onClick={handleCancelAllAssignments}
+                    >
+                        {t('people.cancelAllAssignments')}
+                    </Button>
+                </Box>
+            )}
 
             {/* Mobile FAB — Add Person */}
             {isMobile && (

--- a/src/features/people/presentation/components/PeopleFiltersBar.tsx
+++ b/src/features/people/presentation/components/PeopleFiltersBar.tsx
@@ -1,7 +1,6 @@
-import { Stack, TextField, InputAdornment, FormControl, InputLabel, Select, MenuItem, IconButton, Badge, Collapse, Box, Tooltip, useMediaQuery, useTheme } from '@mui/material';
+import { Stack, TextField, InputAdornment, FormControl, InputLabel, Select, MenuItem, IconButton, Badge, Collapse, Box, useMediaQuery, useTheme } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import FilterListIcon from '@mui/icons-material/FilterList';
-import CancelIcon from '@mui/icons-material/Cancel';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -10,9 +9,6 @@ interface PeopleFiltersBarProps {
     onSearchChange: (value: string) => void;
     assignmentFilter: 'all' | 'assigned' | 'unassigned';
     onAssignmentFilterChange: (value: 'all' | 'assigned' | 'unassigned') => void;
-    canEdit?: boolean;
-    onCancelAllAssignments?: () => void;
-    assignedCount?: number;
 }
 
 /**
@@ -25,9 +21,6 @@ export function PeopleFiltersBar({
     onSearchChange,
     assignmentFilter,
     onAssignmentFilterChange,
-    canEdit = true,
-    onCancelAllAssignments,
-    assignedCount = 0,
 }: PeopleFiltersBarProps) {
     const { t } = useTranslation();
     const theme = useTheme();
@@ -41,7 +34,7 @@ export function PeopleFiltersBar({
     if (isMobile) {
         return (
             <Box sx={{ mb: 2 }}>
-                <Stack direction="row" alignItems="center" justifyContent="space-between">
+                <Stack direction="row" alignItems="center">
                     <IconButton
                         onClick={() => setFiltersOpen(!filtersOpen)}
                         color={activeFilterCount > 0 ? 'primary' : 'default'}
@@ -50,20 +43,6 @@ export function PeopleFiltersBar({
                             <FilterListIcon />
                         </Badge>
                     </IconButton>
-
-                    {onCancelAllAssignments && (
-                        <Tooltip title={t('people.cancelAllAssignments')}>
-                            <span>
-                                <IconButton
-                                    color="error"
-                                    onClick={onCancelAllAssignments}
-                                    disabled={!canEdit || assignedCount === 0}
-                                >
-                                    <CancelIcon />
-                                </IconButton>
-                            </span>
-                        </Tooltip>
-                    )}
                 </Stack>
 
                 <Collapse in={filtersOpen}>

--- a/src/features/people/presentation/components/PeopleTable.tsx
+++ b/src/features/people/presentation/components/PeopleTable.tsx
@@ -198,7 +198,7 @@ export function PeopleTable({
                     </Paper>
                 ) : (
                     <Stack gap={1}>
-                        {people.map((person) => {
+                        {people.map((person, idx) => {
                             const isExpanded = expandedCardId === person.id;
                             const displayName = nameFieldKey ? person.data[nameFieldKey] : undefined;
 
@@ -239,21 +239,24 @@ export function PeopleTable({
                                             size="small"
                                             sx={{ p: 0 }}
                                         />
-                                        {/* ID badge — rounded pill */}
-                                        <Box sx={{
-                                            bgcolor: (theme) => alpha(theme.palette.primary.main, 0.1),
-                                            color: 'primary.main',
-                                            px: 1.5,
-                                            py: 0.6,
-                                            borderRadius: 2.5,
-                                            fontWeight: 700,
-                                            fontSize: '1rem',
-                                            lineHeight: 1.3,
-                                            whiteSpace: 'nowrap',
-                                            flexShrink: 0,
-                                        }}>
-                                            {person.virtualSpaceId || person.id.slice(0, 8)}
-                                        </Box>
+                                        {/* Index badge */}
+                                        <Typography
+                                            sx={{
+                                                color: 'text.secondary',
+                                                fontSize: '0.8rem',
+                                                fontWeight: 600,
+                                                minWidth: 20,
+                                                flexShrink: 0,
+                                            }}
+                                        >
+                                            {idx + 1}
+                                        </Typography>
+                                        {/* Assignment badge — at flex start */}
+                                        {person.assignedSpaceId ? (
+                                            <Chip label={person.assignedSpaceId} size="small" color="success" sx={{ height: 24, fontSize: '0.75rem', flexShrink: 0 }} />
+                                        ) : (
+                                            <Chip label={t('people.unassigned')} size="small" variant="outlined" sx={{ height: 24, fontSize: '0.75rem', flexShrink: 0 }} />
+                                        )}
                                         {/* Name — fills the middle */}
                                         <Typography
                                             noWrap
@@ -261,17 +264,12 @@ export function PeopleTable({
                                                 flex: 1,
                                                 fontSize: '1.1rem',
                                                 fontWeight: 500,
+                                                textAlign: 'center',
                                                 color: displayName ? 'text.primary' : 'text.disabled',
                                             }}
                                         >
                                             {displayName || '–'}
                                         </Typography>
-                                        {/* Assignment chip */}
-                                        {person.assignedSpaceId ? (
-                                            <Chip label={person.assignedSpaceId} size="small" color="success" sx={{ height: 24, fontSize: '0.75rem' }} />
-                                        ) : (
-                                            <Chip label={t('people.unassigned')} size="small" variant="outlined" sx={{ height: 24, fontSize: '0.75rem' }} />
-                                        )}
                                         {/* Chevron */}
                                         <KeyboardArrowDownIcon sx={{
                                             color: 'text.disabled',

--- a/src/features/settings/infrastructure/settingsStore.ts
+++ b/src/features/settings/infrastructure/settingsStore.ts
@@ -112,6 +112,8 @@ export const useSettingsStore = create<SettingsStore>()(
                         settings: createDefaultSettings(),
                         passwordHash: null,
                         isLocked: false,
+                        activeStoreId: null,
+                        activeCompanyId: null,
                     }, false, 'resetSettings'),
 
                 // Cleanup actions
@@ -184,6 +186,9 @@ export const useSettingsStore = create<SettingsStore>()(
 
                         if (serverSettings && Object.keys(serverSettings).length > 0) {
                             Object.assign(updates, serverSettings);
+                            // Remove logos from store-level settings — logos come from company settings only
+                            // (store can override via storeLogoOverride, handled below)
+                            delete updates.logos;
                         }
 
                         if (companySettings && Object.keys(companySettings).length > 0) {
@@ -284,7 +289,7 @@ export const useSettingsStore = create<SettingsStore>()(
                     }
 
                     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                    const { solumConfig, solumMappingConfig, solumArticleFormat, ...otherSettings } = settings;
+                    const { solumConfig, solumMappingConfig, solumArticleFormat, logos, storeLogoOverride, ...otherSettings } = settings;
 
                     let sanitizedSolumConfig: Record<string, unknown> | undefined = undefined;
                     if (solumConfig) {
@@ -296,13 +301,15 @@ export const useSettingsStore = create<SettingsStore>()(
                     const settingsForServer = {
                         ...otherSettings,
                         solumConfig: sanitizedSolumConfig,
+                        // Preserve storeLogoOverride at store level (logos live at company level only)
+                        ...(storeLogoOverride ? { storeLogoOverride } : {}),
                     } as unknown as Partial<SettingsData>;
 
                     set(s => ({ syncCount: s.syncCount + 1 }), false, 'saveSettings/start');
                     try {
                         const { activeCompanyId } = get();
                         const companyWideSettings: Partial<SettingsData> = {};
-                        if (otherSettings.logos) companyWideSettings.logos = otherSettings.logos;
+                        if (logos) companyWideSettings.logos = logos;
                         if (otherSettings.csvConfig) companyWideSettings.csvConfig = otherSettings.csvConfig;
                         if (otherSettings.peopleManagerEnabled !== undefined) companyWideSettings.peopleManagerEnabled = otherSettings.peopleManagerEnabled;
                         if (otherSettings.autoSyncEnabled !== undefined) companyWideSettings.autoSyncEnabled = otherSettings.autoSyncEnabled;
@@ -456,7 +463,8 @@ export const useSettingsStore = create<SettingsStore>()(
             {
                 name: 'settings-store',
                 partialize: (state) => {
-                    const { solumConfig, ...otherSettings } = state.settings;
+                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                    const { solumConfig, logos, storeLogoOverride, ...otherSettings } = state.settings;
                     let cleanSolumConfig = solumConfig;
                     if (solumConfig) {
                         // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -464,7 +472,8 @@ export const useSettingsStore = create<SettingsStore>()(
                         cleanSolumConfig = persistableConfig as typeof solumConfig;
                     }
                     return {
-                        settings: { ...otherSettings, solumConfig: cleanSolumConfig },
+                        // Don't persist logos — always fetch fresh from server to prevent cross-company leaks
+                        settings: { ...otherSettings, solumConfig: cleanSolumConfig, logos: {} },
                         passwordHash: state.passwordHash,
                         activeStoreId: state.activeStoreId,
                         activeCompanyId: state.activeCompanyId,


### PR DESCRIPTION
## Summary
- **Logo leak fix**: Logos no longer saved to store-level settings (company-only), stripped from store settings on fetch, excluded from localStorage persistence, and `activeStoreId`/`activeCompanyId` reset on settings clear — prevents stale logos leaking between companies/stores
- **People mobile cards**: Replaced DB ID badge with row index + assignment chip (assigned space or "Unassigned"), with assignment at flex-start and person name centered
- **Unassign All button**: Moved from top filters bar to page bottom on mobile, rendered as tertiary (text) button aligned to start

## Test plan
- [ ] Switch between companies/stores — verify logos update correctly with no stale logos
- [ ] Verify store logo override still works when set
- [ ] Reload page after switching companies — no stale logos from localStorage
- [ ] Open People page on mobile — cards show index, assignment chip, then centered name
- [ ] Verify "Unassign All" button appears at bottom of people list on mobile
- [ ] Desktop people table unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)