### PR TITLE
fix: restore logo save to store level

### DIFF
--- a/src/features/settings/infrastructure/settingsStore.ts
+++ b/src/features/settings/infrastructure/settingsStore.ts
@@ -289,7 +289,7 @@ export const useSettingsStore = create<SettingsStore>()(
                     }
 
                     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                    const { solumConfig, solumMappingConfig, solumArticleFormat, logos, storeLogoOverride, ...otherSettings } = settings;
+                    const { solumConfig, solumMappingConfig, solumArticleFormat, ...otherSettings } = settings;
 
                     let sanitizedSolumConfig: Record<string, unknown> | undefined = undefined;
                     if (solumConfig) {
@@ -301,15 +301,13 @@ export const useSettingsStore = create<SettingsStore>()(
                     const settingsForServer = {
                         ...otherSettings,
                         solumConfig: sanitizedSolumConfig,
-                        // Preserve storeLogoOverride at store level (logos live at company level only)
-                        ...(storeLogoOverride ? { storeLogoOverride } : {}),
                     } as unknown as Partial<SettingsData>;
 
                     set(s => ({ syncCount: s.syncCount + 1 }), false, 'saveSettings/start');
                     try {
                         const { activeCompanyId } = get();
                         const companyWideSettings: Partial<SettingsData> = {};
-                        if (logos) companyWideSettings.logos = logos;
+                        if (otherSettings.logos) companyWideSettings.logos = otherSettings.logos;
                         if (otherSettings.csvConfig) companyWideSettings.csvConfig = otherSettings.csvConfig;
                         if (otherSettings.peopleManagerEnabled !== undefined) companyWideSettings.peopleManagerEnabled = otherSettings.peopleManagerEnabled;
                         if (otherSettings.autoSyncEnabled !== undefined) companyWideSettings.autoSyncEnabled = otherSettings.autoSyncEnabled;


### PR DESCRIPTION
## Summary
- Reverts the store-level logo exclusion from #137 that caused logo saves to silently fail for non-admin users
- Logos are again saved to both store and company levels (store as fallback)
- The fetch-side fix from #137 remains: company logos are authoritative, store logos are stripped before merge, and logos are excluded from localStorage

**Root cause:** #137 excluded logos from store-level saves, but the company-level save requires admin role — non-admin users' logo changes were silently lost on page refresh.

## Test plan
- [ ] Upload a new logo — verify it persists after page refresh
- [ ] Switch between stores/companies — verify no logo leak
- [ ] Test with non-admin user — logo changes should persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)