### PR TITLE
fix: persist logos to localStorage for reliable display

### DIFF
--- a/src/features/settings/infrastructure/settingsStore.ts
+++ b/src/features/settings/infrastructure/settingsStore.ts
@@ -460,8 +460,7 @@ export const useSettingsStore = create<SettingsStore>()(
             {
                 name: 'settings-store',
                 partialize: (state) => {
-                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                    const { solumConfig, logos, storeLogoOverride, ...otherSettings } = state.settings;
+                    const { solumConfig, ...otherSettings } = state.settings;
                     let cleanSolumConfig = solumConfig;
                     if (solumConfig) {
                         // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -469,8 +468,9 @@ export const useSettingsStore = create<SettingsStore>()(
                         cleanSolumConfig = persistableConfig as typeof solumConfig;
                     }
                     return {
-                        // Don't persist logos — always fetch fresh from server to prevent cross-company leaks
-                        settings: { ...otherSettings, solumConfig: cleanSolumConfig, logos: {} },
+                        // Logos persist to localStorage for instant display on reload.
+                        // Cross-company leaks are prevented by resetSettings() during context switches.
+                        settings: { ...otherSettings, solumConfig: cleanSolumConfig },
                         passwordHash: state.passwordHash,
                         activeStoreId: state.activeStoreId,
                         activeCompanyId: state.activeCompanyId,


### PR DESCRIPTION
## Summary
- Stop excluding logos from Zustand persist — logos now cache in localStorage
- On page reload, logos display instantly from cache (no flash of defaults)
- Server fetch still runs and updates logos if they've changed
- Cross-company leak prevention is handled by `resetSettings()` during context switches (unchanged)

**Root cause:** Previous fix excluded logos from `partialize`, meaning localStorage always had `logos: {}`. On reload, the app showed default logos while waiting for server fetch. If the fetch timing was off or failed silently, the new logo never appeared.

## Test plan
- [ ] Upload logo → refresh → logo persists immediately
- [ ] Switch companies → verify correct logos (no leak)
- [ ] Clear localStorage manually → refresh → logos load from server

🤖 Generated with [Claude Code](https://claude.com/claude-code)