### PR TITLE
fix: add glass toolbar to Labels and AIMS Management pages

### DIFF
--- a/src/features/aims-management/presentation/AimsManagementPage.tsx
+++ b/src/features/aims-management/presentation/AimsManagementPage.tsx
@@ -21,6 +21,7 @@ import {
 import RouterIcon from '@mui/icons-material/Router';
 import LabelIcon from '@mui/icons-material/Label';
 import AddIcon from '@mui/icons-material/Add';
+import { glassToolbarSx } from '@shared/presentation/styles/glassToolbar';
 import UploadIcon from '@mui/icons-material/Upload';
 import WifiIcon from '@mui/icons-material/Wifi';
 import WifiOffIcon from '@mui/icons-material/WifiOff';
@@ -140,14 +141,16 @@ export function AimsManagementPage() {
                     </Typography>
                 </Box>
                 {canManage && activeTab === 1 && (
-                    <Button
-                        variant="contained"
-                        startIcon={<AddIcon />}
-                        onClick={() => setRegisterDialogOpen(true)}
-                        sx={{ whiteSpace: 'nowrap', display: { xs: 'none', md: 'inline-flex' } }}
-                    >
-                        {t('aims.registerGateway')}
-                    </Button>
+                    <Box sx={{ ...glassToolbarSx, display: { xs: 'none', md: 'inline-flex' } }}>
+                        <Button
+                            variant="contained"
+                            startIcon={<AddIcon />}
+                            onClick={() => setRegisterDialogOpen(true)}
+                            sx={{ whiteSpace: 'nowrap' }}
+                        >
+                            {t('aims.registerGateway')}
+                        </Button>
+                    </Box>
                 )}
             </Stack>
 

--- a/src/features/labels/presentation/LabelsPage.tsx
+++ b/src/features/labels/presentation/LabelsPage.tsx
@@ -44,6 +44,7 @@ import {
     Close as CloseIcon,
 } from '@mui/icons-material';
 import FilterListIcon from '@mui/icons-material/FilterList';
+import { glassToolbarSx } from '@shared/presentation/styles/glassToolbar';
 import { useTranslation } from 'react-i18next';
 import { useLabelsStore } from '../infrastructure/labelsStore';
 import { useAuthStore } from '@features/auth/infrastructure/authStore';
@@ -493,13 +494,12 @@ export function LabelsPage() {
                 <Typography variant="h4" component="h1" sx={{ fontSize: { xs: '1.25rem', md: '2rem' }, fontWeight: 500 }}>
                     {t('labels.title', 'Labels Management')}
                 </Typography>
-                <Stack direction="row" gap={1}>
+                <Box sx={{ ...glassToolbarSx, display: { xs: 'none', md: 'inline-flex' } }}>
                     <Button
                         variant="contained"
                         startIcon={<AddIcon />}
                         disabled={!canEdit}
                         onClick={() => handleOpenLinkDialog()}
-                        sx={{ display: { xs: 'none', md: 'inline-flex' } }}
                     >
                         {t('labels.linkNew', 'Link Label')}
                     </Button>
@@ -508,31 +508,30 @@ export function LabelsPage() {
                         startIcon={<ImageIcon />}
                         disabled={!canEdit}
                         onClick={() => handleOpenAssignImageDialog()}
-                        sx={{ display: { xs: 'none', md: 'inline-flex' } }}
                     >
                         {t('imageLabels.assignImage', 'Assign Image')}
                     </Button>
-                    <Tooltip title={t('common.refresh', 'Refresh')}>
-                        <span style={{ display: 'inline-flex' }}>
-                            <IconButton
-                                onClick={handleRefresh}
-                                disabled={isLoading}
-                                sx={{ display: { xs: 'inline-flex', sm: 'none' } }}
-                            >
-                                <RefreshIcon />
-                            </IconButton>
-                        </span>
-                    </Tooltip>
-                    <Button
-                        variant="text"
-                        startIcon={<RefreshIcon />}
-                        onClick={handleRefresh}
-                        disabled={isLoading}
-                        sx={{ display: { xs: 'none', sm: 'inline-flex' } }}
-                    >
-                        {t('common.refresh', 'Refresh')}
-                    </Button>
-                </Stack>
+                </Box>
+                <Tooltip title={t('common.refresh', 'Refresh')}>
+                    <span style={{ display: 'inline-flex' }}>
+                        <IconButton
+                            onClick={handleRefresh}
+                            disabled={isLoading}
+                            sx={{ display: { xs: 'inline-flex', sm: 'none' } }}
+                        >
+                            <RefreshIcon />
+                        </IconButton>
+                    </span>
+                </Tooltip>
+                <Button
+                    variant="text"
+                    startIcon={<RefreshIcon />}
+                    onClick={handleRefresh}
+                    disabled={isLoading}
+                    sx={{ display: { xs: 'none', sm: 'inline-flex' } }}
+                >
+                    {t('common.refresh', 'Refresh')}
+                </Button>
             </Stack>
 
             {/* Error Alert */}

--- a/src/features/labels/presentation/LabelsPage.tsx
+++ b/src/features/labels/presentation/LabelsPage.tsx
@@ -511,27 +511,27 @@ export function LabelsPage() {
                     >
                         {t('imageLabels.assignImage', 'Assign Image')}
                     </Button>
+                    <Button
+                        variant="text"
+                        startIcon={<RefreshIcon />}
+                        onClick={handleRefresh}
+                        disabled={isLoading}
+                    >
+                        {t('common.refresh', 'Refresh')}
+                    </Button>
                 </Box>
+                {/* Mobile: icon-only refresh */}
                 <Tooltip title={t('common.refresh', 'Refresh')}>
                     <span style={{ display: 'inline-flex' }}>
                         <IconButton
                             onClick={handleRefresh}
                             disabled={isLoading}
-                            sx={{ display: { xs: 'inline-flex', sm: 'none' } }}
+                            sx={{ display: { xs: 'inline-flex', md: 'none' } }}
                         >
                             <RefreshIcon />
                         </IconButton>
                     </span>
                 </Tooltip>
-                <Button
-                    variant="text"
-                    startIcon={<RefreshIcon />}
-                    onClick={handleRefresh}
-                    disabled={isLoading}
-                    sx={{ display: { xs: 'none', sm: 'inline-flex' } }}
-                >
-                    {t('common.refresh', 'Refresh')}
-                </Button>
             </Stack>
 
             {/* Error Alert */}


### PR DESCRIPTION
## Summary
Labels page and AIMS Management page were missing the glass toolbar wrapper around their action buttons. Now consistent with Spaces, Conference, People, and Dashboard.

- **Labels**: Link Label + Assign Image buttons wrapped in glass toolbar (desktop/tablet)
- **AIMS Management**: Register Gateway button wrapped in glass toolbar (desktop/tablet)

## Test plan
- [ ] Labels page: glass toolbar visible around action buttons on desktop/tablet
- [ ] AIMS Management → Gateways tab: glass toolbar around Register Gateway button
- [ ] Mobile: buttons still hidden (FAB used instead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)