### PR TITLE
fix: prevent silent save failure when store missing peopleManagerConfig

### DIFF
--- a/server/src/features/people/service.ts
+++ b/server/src/features/people/service.ts
@@ -222,6 +222,36 @@ export const peopleService = {
             { assignedSpaceId: spaceId }
         );
 
+        // Safety net: ensure the store has peopleManagerConfig with totalSpaces
+        // so the client SpaceSelector/validation works correctly
+        try {
+            const store = await prisma.store.findUnique({ where: { id: person.storeId } });
+            const storeSettings = (store?.settings as Record<string, any>) || {};
+            if (!storeSettings.peopleManagerConfig?.totalSpaces) {
+                // Count current max assigned space to set a sensible default
+                const maxSpace = await prisma.person.aggregate({
+                    where: { storeId: person.storeId, assignedSpaceId: { not: null } },
+                    _max: { assignedSpaceId: true },
+                });
+                const maxNum = parseInt(maxSpace._max.assignedSpaceId || '0', 10) || 0;
+                const totalSpaces = Math.max(maxNum, parseInt(spaceId, 10), 1);
+
+                await prisma.store.update({
+                    where: { id: person.storeId },
+                    data: {
+                        settings: {
+                            ...storeSettings,
+                            peopleManagerConfig: { totalSpaces },
+                        },
+                    },
+                });
+                appLogger.info('PeopleService', `Auto-initialized peopleManagerConfig for store ${person.storeId}`, { totalSpaces });
+            }
+        } catch (err: any) {
+            // Non-critical — log and continue
+            appLogger.warn('PeopleService', `Failed to auto-initialize peopleManagerConfig: ${err.message}`);
+        }
+
         return updated;
     },
 

--- a/src/features/people/presentation/PersonDialog.tsx
+++ b/src/features/people/presentation/PersonDialog.tsx
@@ -154,14 +154,15 @@ export function PersonDialog({ open, onClose, person }: PersonDialogProps) {
     const validate = () => {
         const newErrors: Record<string, string> = {};
 
-        // No need to validate ID for add mode - it will be auto-generated
-
-        // Check if assigned space ID is within range
+        // Validate space assignment only for NEW selections (not existing assignments)
+        // SpaceSelector already constrains options to 1..totalSpaces, so this is a safety check.
+        // Skip range check when totalSpaces is 0 (settings not loaded or missing for this store)
+        // to avoid silently blocking saves.
         if (formData.assignedSpaceId) {
             const spaceNum = parseInt(formData.assignedSpaceId, 10);
             if (isNaN(spaceNum) || spaceNum < 1) {
                 newErrors.assignedSpaceId = t('validation.invalidSpaceId');
-            } else if (spaceNum > totalSpaces) {
+            } else if (totalSpaces > 0 && spaceNum > totalSpaces) {
                 newErrors.assignedSpaceId = tWithSpaceType('people.spaceExceedsTotal');
             }
         }


### PR DESCRIPTION
## Summary
Two safety nets to prevent the אולם ארגמן class of bug from recurring:

- **Client validate() guard**: Skip `totalSpaces` range check when `totalSpaces` is 0 (settings missing). SpaceSelector already constrains valid options — this redundant validation was silently blocking all saves
- **Server auto-init**: `assignToSpace()` auto-initializes `peopleManagerConfig` on the store if missing, computing `totalSpaces` from the max assigned space number. Ensures the client always has valid settings after any assignment

**Root cause**: Store-level settings can diverge from company settings. אולם ארגמן had no `peopleManagerConfig` while אולם ייטב לב had `{"totalSpaces": 25}`. DB was fixed directly for immediate relief.

## Test plan
- [ ] Edit person in אולם ארגמן — save works
- [ ] Edit person in אולם ייטב לב — still works  
- [ ] Assign space to person in a store with no peopleManagerConfig — config auto-created
- [ ] Add person with space in a store with totalSpaces=0 — no silent failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)