### PR TITLE
fix: spaces field mapping — remove Name column, sort by article format order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Spaces mode field mapping** — removed dedicated "Name" column/field from spaces table and edit dialog; all mapped fields now appear equally, sorted by article format order
+- **Space edit dialog field order** — dynamic fields now sorted by `order` property (article format order) instead of arbitrary config iteration order
+- **Vite proxy IPv6 resolution** — use `127.0.0.1` instead of `localhost` to avoid stale IPv6 processes intercepting API proxy traffic on Windows
+
 ## [2.14.0] — 2026-03-16 — Native App Adaptations
 
 ### Added

--- a/docs/wiki/Chapter-5-—-Integration-&-Synchronization.md
+++ b/docs/wiki/Chapter-5-—-Integration-&-Synchronization.md
@@ -131,6 +131,17 @@ The Article Builder maps entity data to the AIMS article format:
 3. **Global field assignments** (from company settings) inject static values across all articles.
 4. **Conference mapping** maps `meetingName`, `meetingTime`, and `participants` to configurable AIMS fields.
 
+#### Mode-Specific Field Display
+
+The UI renders mapped fields differently depending on the operating mode:
+
+| Aspect | Spaces Mode | People Mode |
+|--------|-------------|-------------|
+| **Dedicated Name column** | No — all mapped fields are equal | Yes — `articleName` mapping shown as dedicated "Name" column/field |
+| **Table column order** | Sorted by `order` property (article format order) | Same |
+| **Edit dialog** | ID at top, then all mapped fields by article format order | ID at top, dedicated Name field, then remaining fields |
+| **Unique identifier** | `uniqueIdField` from mapping config | Same, plus `articleName` as the display name |
+
 ### 5.5 Label Operations
 
 Labels are the physical e-ink devices managed through AIMS:

--- a/src/features/space/presentation/SpaceDialog.tsx
+++ b/src/features/space/presentation/SpaceDialog.tsx
@@ -138,13 +138,15 @@ export function SpaceDialog({
         }));
     };
 
-    // Identify the field key used for the "Name"
+    // In SOLUM API spaces mode, there is NO dedicated name field — all mapped fields
+    // appear equally, sorted by their article format order.
+    // In SFTP mode, roomName is still used as the dedicated name field.
     const nameFieldKey = useMemo(() => {
-        if (workingMode === 'SOLUM_API' && solumMappingConfig) {
-            return solumMappingConfig.mappingInfo?.articleName || 'roomName';
+        if (workingMode === 'SOLUM_API') {
+            return undefined; // No dedicated name — all fields shown by article format order
         }
-        return 'roomName';
-    }, [workingMode, solumMappingConfig]);
+        return 'roomName'; // SFTP mode
+    }, [workingMode]);
 
     // Get dynamic fields based on working mode
     const dynamicFields = useMemo(() => {
@@ -161,12 +163,13 @@ export function SpaceDialog({
                     if (!fieldConfig.visible) return false;
                     // Exclude uniqueIdField (already shown as ID)
                     if (fieldKey === uniqueIdField) return false;
-                    // Exclude field used as Name (already shown as Name)
-                    if (fieldKey === nameFieldKey) return false;
+                    // Exclude field used as Name (already shown as dedicated Name field — people mode only)
+                    if (nameFieldKey && fieldKey === nameFieldKey) return false;
                     // Exclude globally assigned fields (they apply to all entities automatically)
                     if (globalFieldKeys.includes(fieldKey)) return false;
                     return true;
                 })
+                .sort(([, a], [, b]) => (a.order ?? Infinity) - (b.order ?? Infinity))
                 .map(([fieldKey, fieldConfig]) => {
                     // Use friendly names if they exist and are not just the field key itself
                     // (default config sets friendly names to field key, which is not user-friendly)
@@ -212,13 +215,15 @@ export function SpaceDialog({
                         helperText={errors.id || (space ? t('spaces.idCannotChange') : t('spaces.uniqueIdentifier'))}
                     />
 
-                    {/* Name - Dynamically Resolved Field */}
-                    <TextField
-                        fullWidth
-                        label={t('spaces.name')}
-                        value={formData.data?.[nameFieldKey] || ''}
-                        onChange={(e) => handleDynamicDataChange(nameFieldKey, e.target.value)}
-                    />
+                    {/* Name - Dedicated field only in people mode or SFTP mode */}
+                    {nameFieldKey && (
+                        <TextField
+                            fullWidth
+                            label={t('spaces.name')}
+                            value={formData.data?.[nameFieldKey] || ''}
+                            onChange={(e) => handleDynamicDataChange(nameFieldKey, e.target.value)}
+                        />
+                    )}
 
                     {/* Dynamic Fields */}
                     {dynamicFields.length > 0 && (

--- a/src/features/space/presentation/SpacesManagementView.tsx
+++ b/src/features/space/presentation/SpacesManagementView.tsx
@@ -353,7 +353,7 @@ export function SpacesManagementView() {
     const isPeopleMode = settingsController.settings.peopleManagerEnabled === true;
     const nameFieldKey = isPeopleMode
         ? settingsController.settings.solumMappingConfig?.mappingInfo?.articleName
-        : undefined;
+        : undefined; // In spaces mode, name field is NOT special — it appears as a regular mapped field
 
     // Get visible fields from mapping config for dynamic table columns
     const visibleFields = useMemo(() => {


### PR DESCRIPTION
## Summary
- Remove dedicated "Name" column/field from spaces table and edit dialog in SOLUM API mode — all mapped fields now appear equally
- Sort dynamic fields in SpaceDialog by `order` property (article format order) instead of arbitrary config iteration order
- People mode unchanged — still uses dedicated Name column via `articleName` mapping

Closes #149

## Test plan
- [ ] Verify spaces table shows all mapped fields as regular columns (no dedicated "Name" column)
- [ ] Verify space edit dialog shows ID at top, then all mapped fields sorted by article format order
- [ ] Verify people mode still has dedicated Name column in table and Name field in PersonDialog
- [ ] Verify SFTP mode still works with roomName as dedicated Name field

🤖 Generated with [Claude Code](https://claude.com/claude-code)