### PR TITLE
fix: spaces edit dialog field order (hotfix)

### DIFF
--- a/src/features/space/presentation/SpaceDialog.tsx
+++ b/src/features/space/presentation/SpaceDialog.tsx
@@ -138,13 +138,15 @@ export function SpaceDialog({
         }));
     };
 
-    // Identify the field key used for the "Name"
+    // In SOLUM API spaces mode, there is NO dedicated name field — all mapped fields
+    // appear equally, sorted by their article format order.
+    // In SFTP mode, roomName is still used as the dedicated name field.
     const nameFieldKey = useMemo(() => {
-        if (workingMode === 'SOLUM_API' && solumMappingConfig) {
-            return solumMappingConfig.mappingInfo?.articleName || 'roomName';
+        if (workingMode === 'SOLUM_API') {
+            return undefined; // No dedicated name — all fields shown by article format order
         }
-        return 'roomName';
-    }, [workingMode, solumMappingConfig]);
+        return 'roomName'; // SFTP mode
+    }, [workingMode]);
 
     // Get dynamic fields based on working mode
     const dynamicFields = useMemo(() => {
@@ -161,12 +163,13 @@ export function SpaceDialog({
                     if (!fieldConfig.visible) return false;
                     // Exclude uniqueIdField (already shown as ID)
                     if (fieldKey === uniqueIdField) return false;
-                    // Exclude field used as Name (already shown as Name)
-                    if (fieldKey === nameFieldKey) return false;
+                    // Exclude field used as Name (already shown as dedicated Name field — people mode only)
+                    if (nameFieldKey && fieldKey === nameFieldKey) return false;
                     // Exclude globally assigned fields (they apply to all entities automatically)
                     if (globalFieldKeys.includes(fieldKey)) return false;
                     return true;
                 })
+                .sort(([, a], [, b]) => (a.order ?? Infinity) - (b.order ?? Infinity))
                 .map(([fieldKey, fieldConfig]) => {
                     // Use friendly names if they exist and are not just the field key itself
                     // (default config sets friendly names to field key, which is not user-friendly)
@@ -212,13 +215,15 @@ export function SpaceDialog({
                         helperText={errors.id || (space ? t('spaces.idCannotChange') : t('spaces.uniqueIdentifier'))}
                     />
 
-                    {/* Name - Dynamically Resolved Field */}
-                    <TextField
-                        fullWidth
-                        label={t('spaces.name')}
-                        value={formData.data?.[nameFieldKey] || ''}
-                        onChange={(e) => handleDynamicDataChange(nameFieldKey, e.target.value)}
-                    />
+                    {/* Name - Dedicated field only in SFTP mode */}
+                    {nameFieldKey && (
+                        <TextField
+                            fullWidth
+                            label={t('spaces.name')}
+                            value={formData.data?.[nameFieldKey] || ''}
+                            onChange={(e) => handleDynamicDataChange(nameFieldKey, e.target.value)}
+                        />
+                    )}
 
                     {/* Dynamic Fields */}
                     {dynamicFields.length > 0 && (


### PR DESCRIPTION
## Summary
- Remove dedicated "Name" field from space edit dialog in SOLUM API mode — all mapped fields appear equally
- Sort dynamic fields by `order` property (article format order) instead of PostgreSQL jsonb key order
- SFTP mode and people mode unchanged

**Hotfix for production** — cherry-picked from #150 (`feat/native-ui-rewrite`)

Closes #149

## Verified
- `tsc --noEmit` — clean
- `npm run build` — production build successful

## Test plan
- [ ] Open space edit dialog on DMC store 01 — fields should appear in article format order (Room Name → Doctor 1 Name → Doctor 1 Title → Doctor 1 Specialty → Doctor 2 Name → ...)
- [ ] Verify no dedicated "Name" field above the dynamic fields
- [ ] Verify people mode still has dedicated Name field (if applicable)
- [ ] Verify SFTP mode still works with roomName

🤖 Generated with [Claude Code](https://claude.com/claude-code)