### PR TITLE
Add memory limits to all containers

### DIFF
--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -33,6 +33,12 @@ services:
     restart: unless-stopped
     networks:
       - global-network
+    deploy:
+      resources:
+        limits:
+          memory: 64M
+        reservations:
+          memory: 16M
 
   # ======================
   # Server — Node.js API
@@ -61,6 +67,12 @@ services:
     restart: unless-stopped
     networks:
       - global-network
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+        reservations:
+          memory: 64M
 
 networks:
   global-network:

--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -27,6 +27,12 @@ services:
     restart: unless-stopped
     networks:
       - global-network
+    deploy:
+      resources:
+        limits:
+          memory: 64M
+        reservations:
+          memory: 16M
 
 volumes:
   redis_data:


### PR DESCRIPTION
## Summary
- Added `deploy.resources.limits` to all ElectisSpace services
- Client (nginx): 64M, server (API): 256M, redis: 64M
- Total ElectisSpace allocation: ~384M

## Context
Server resource audit found RAM at AMBER status with 1.5GB active swap. These limits prevent unbounded memory growth.

## Test plan
- [ ] Verify containers start successfully with new limits
- [ ] Monitor `docker stats` after deploy to confirm no OOM kills

🤖 Generated with [Claude Code](https://claude.com/claude-code)