### PR TITLE
fix: lowercase email inputs + fix server Dockerfile build

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -8,8 +8,6 @@
 # Stage 1: Build server (TypeScript)
 FROM node:22-alpine AS server-builder
 
-RUN npm install -g npm@latest
-
 WORKDIR /app
 
 COPY server/package*.json ./
@@ -26,8 +24,6 @@ RUN npm run build
 
 # Stage 2: Production runtime
 FROM node:22-alpine AS production
-
-RUN npm install -g npm@latest
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Auto-lowercase email input on login page and user creation dialog as the user types
- Added `.transform(v => v.toLowerCase())` to all server-side Zod email schemas (auth + users) as a safety net
- Removed `npm install -g npm@latest` from both stages of the server Dockerfile — Node 22 Alpine already ships with a modern npm, and the self-upgrade was failing (missing `promise-retry` module)

Closes #156

## Test plan
- [ ] Login with an email containing uppercase letters — verify it gets lowercased in the input field
- [ ] Create a new user with uppercase email — verify it's stored lowercase
- [ ] Verify 2FA, forgot password, and reset password flows accept mixed-case emails
- [ ] CI/CD Docker build succeeds (server Dockerfile no longer fails on npm self-upgrade)

https://claude.ai/code/session_01NnpvjzfBcQWVhN61hJX5g7