### PR TITLE
fix: AIMS responseCode 200 treated as error on label link

### DIFF
--- a/server/src/shared/infrastructure/services/aimsGateway.ts
+++ b/server/src/shared/infrastructure/services/aimsGateway.ts
@@ -638,10 +638,13 @@ export class AIMSGateway {
                 const result = await solumService.linkLabel(config, currentToken, labelCode, articleId, templateName);
 
                 // Check AIMS response body for non-success responseCode
+                // AIMS uses various success codes: "0000", "SUCCESS", "200"
                 const responseCode = result?.responseCode || '';
                 const responseMessage = typeof result?.responseMessage === 'string' ? result.responseMessage : '';
+                const isSuccess = !responseCode || responseCode === '0000' || responseCode === '200'
+                    || responseCode.toUpperCase() === 'SUCCESS';
 
-                if (responseCode && responseCode !== '0000' && responseCode.toUpperCase() !== 'SUCCESS') {
+                if (!isSuccess) {
                     const combinedMsg = `${responseCode}: ${responseMessage}`;
 
                     // Auto-whitelist on whitelist-related errors
@@ -654,7 +657,9 @@ export class AIMSGateway {
                             const retryResult = await solumService.linkLabel(config, currentToken, labelCode, articleId, templateName);
                             const retryCode = retryResult?.responseCode || '';
                             const retryMsg = typeof retryResult?.responseMessage === 'string' ? retryResult.responseMessage : '';
-                            if (retryCode && retryCode !== '0000' && retryCode.toUpperCase() !== 'SUCCESS') {
+                            const retryIsSuccess = !retryCode || retryCode === '0000' || retryCode === '200'
+                                || retryCode.toUpperCase() === 'SUCCESS';
+                            if (!retryIsSuccess) {
                                 throw new AimsOperationError(
                                     `Link label failed after whitelist: ${retryCode}: ${retryMsg}`,
                                     retryCode,


### PR DESCRIPTION
## Summary

- AIMS returns `responseCode: "200"` with `responseMessage: "SUCCESS"` on successful label assignment
- Our code only checked for `"0000"` and `"SUCCESS"` as success codes — `"200"` fell through to the error path, returning 502 to the client
- Add `"200"` to the success code check in both the initial link and whitelist-retry paths

## Test plan

- [ ] Assign a label to a space — should succeed without error notification
- [ ] Unassign and reassign — verify both operations work
- [ ] Check logs: successful link should NOT show "Link label AIMS error"

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)