### PR TITLE
fix: label assign dialog — success notification + clear fields

### DIFF
--- a/src/features/labels/presentation/LinkLabelDialog.tsx
+++ b/src/features/labels/presentation/LinkLabelDialog.tsx
@@ -60,6 +60,7 @@ export function LinkLabelDialog({
     const [articleId, setArticleId] = useState(initialArticleId);
     const [templateName, setTemplateName] = useState('');
     const [error, setError] = useState<string | null>(null);
+    const [success, setSuccess] = useState<string | null>(null);
     const [isSubmitting, setIsSubmitting] = useState(false);
     
     // Scanner state
@@ -77,6 +78,7 @@ export function LinkLabelDialog({
             setArticleId(initialArticleId);
             setTemplateName('');
             setError(null);
+            setSuccess(null);
         }
     }, [open, initialLabelCode, initialArticleId]);
 
@@ -128,6 +130,7 @@ export function LinkLabelDialog({
 
     const handleSubmit = useCallback(async () => {
         setError(null);
+        setSuccess(null);
 
         // Validation
         if (!labelCode.trim()) {
@@ -142,13 +145,20 @@ export function LinkLabelDialog({
         setIsSubmitting(true);
         try {
             await onLink(labelCode.trim(), articleId.trim(), templateName.trim() || undefined);
-            onClose();
+            // Show success and clear fields for next assignment
+            setSuccess(t('labels.link.success', 'Label linked successfully'));
+            setLabelCode('');
+            setArticleId('');
+            setTemplateName('');
+            autoSubmittedRef.current = false;
+            // Auto-dismiss success after 1.5 seconds
+            setTimeout(() => setSuccess(null), 1500);
         } catch (err: any) {
             setError(err.message || t('labels.link.error', 'Failed to link label'));
         } finally {
             setIsSubmitting(false);
         }
-    }, [labelCode, articleId, templateName, onLink, onClose, t]);
+    }, [labelCode, articleId, templateName, onLink, t]);
 
     // Auto-submit: when both label code and a valid article are present, submit immediately
     const autoSubmittedRef = useRef(false);
@@ -187,6 +197,11 @@ export function LinkLabelDialog({
 
                 <DialogContent>
                     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, pt: 1 }}>
+                        {success && (
+                            <Alert severity="success">
+                                {success}
+                            </Alert>
+                        )}
                         {error && (
                             <Alert severity="error" onClose={() => setError(null)}>
                                 {error}

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1705,6 +1705,7 @@
             "button": "Link",
             "labelRequired": "Label code is required",
             "articleRequired": "Article ID is required",
+            "success": "Label linked successfully",
             "error": "Failed to link label",
             "linkFailed": "Failed to link label",
             "linkFailedWhitelist": "Label not whitelisted. Auto-whitelist failed.",

--- a/src/locales/he/common.json
+++ b/src/locales/he/common.json
@@ -1717,6 +1717,7 @@
             "button": "קשר",
             "labelRequired": "קוד תגית הוא שדה חובה",
             "articleRequired": "מזהה מוצר הוא שדה חובה",
+            "success": "התגית קושרה בהצלחה",
             "error": "שגיאה בקישור התגית",
             "linkFailed": "שיוך תגית נכשל",
             "linkFailedWhitelist": "התגית אינה ב-Whitelist. הוספה אוטומטית נכשלה.",


### PR DESCRIPTION
## Summary

- On successful label assignment, show inline success Alert for 1.5s instead of closing dialog
- Clear label code, article ID, and template fields so user can assign another label immediately
- Added `labels.link.success` translation key (EN + HE)

## Test plan

- [ ] Open link label dialog, assign a label — should see green "Label linked successfully" alert
- [ ] Fields should clear after success
- [ ] Dialog stays open — can assign another label right away
- [ ] Success alert auto-dismisses after ~1.5 seconds
- [ ] Error case still shows red error alert as before
- [ ] Auto-submit after scanning both codes still works (with success notification)

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)