### PR TITLE
fix: remove unused setSpaces import in MainLayout

### DIFF
--- a/src/shared/presentation/layouts/MainLayout.tsx
+++ b/src/shared/presentation/layouts/MainLayout.tsx
@@ -7,8 +7,6 @@ import { checkNavigationGuard } from '../navigationGuard';
 import { AppHeader } from './AppHeader';
 import { useSyncStore } from '@features/sync/infrastructure/syncStore';
 import { useSettingsStore } from '@features/settings/infrastructure/settingsStore';
-import { useSpacesStore } from '@features/space/infrastructure/spacesStore';
-
 import { useBackendSyncController } from '@features/sync/application/useBackendSyncController';
 import { SyncStatusIndicator } from '../components/SyncStatusIndicator';
 import { useSpaceTypeLabels } from '@features/settings/hooks/useSpaceTypeLabels';
@@ -89,7 +87,6 @@ export function MainLayout({ children }: MainLayoutProps) {
     // Only allow sync when auth session is fully restored and valid
     const authReady = isAuthenticated && isInitialized;
     const effectiveStoreId = authReady ? activeStoreId : null;
-    const setSpaces = useSpacesStore(state => state.setSpaces);
 
     // Android hardware back button: close open overlays first, then navigate back
     useAndroidBackButton({


### PR DESCRIPTION
Closes #165

## Summary
- Removes unused `setSpaces` selector and `useSpacesStore` import from `MainLayout.tsx`
- Leftover from the merge of #166 — spaces refresh is now handled via SSE `spaces:changed` event, so this import is no longer needed
- Fixes CI build failure (`TS6133: 'setSpaces' is declared but its value is never read`)

## Test plan
- [ ] CI build passes (the only change is removing 3 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)