### PR TITLE
fix(ci): retry npm ci on transient ECONNRESET in Docker build

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -10,8 +10,16 @@ FROM node:20-alpine AS frontend
 
 WORKDIR /app
 
+# Harden npm against transient CI network failures (ECONNRESET on the registry).
+# Per-request retries + generous timeouts; wrapped in a shell retry so a full
+# connection drop mid-install gets a second or third chance.
+ENV NPM_CONFIG_FETCH_RETRIES=5 \
+    NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=20000 \
+    NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=180000 \
+    NPM_CONFIG_FETCH_TIMEOUT=300000
+
 COPY package*.json ./
-RUN npm ci
+RUN npm ci || (echo "npm ci retry 1/2" && sleep 15 && npm ci) || (echo "npm ci retry 2/2" && sleep 45 && npm ci)
 
 COPY src/ ./src/
 COPY public/ ./public/

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -10,10 +10,16 @@ FROM node:22-alpine AS server-builder
 
 WORKDIR /app
 
+# Harden npm against transient CI network failures (ECONNRESET on the registry).
+ENV NPM_CONFIG_FETCH_RETRIES=5 \
+    NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=20000 \
+    NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=180000 \
+    NPM_CONFIG_FETCH_TIMEOUT=300000
+
 COPY server/package*.json ./
 COPY server/prisma ./prisma/
 
-RUN npm ci
+RUN npm ci || (echo "npm ci retry 1/2" && sleep 15 && npm ci) || (echo "npm ci retry 2/2" && sleep 45 && npm ci)
 RUN npx prisma generate
 
 COPY server/prisma.config.ts ./prisma.config.ts
@@ -37,8 +43,14 @@ RUN addgroup -g 1001 -S nodejs && \
 # Copy package files
 COPY server/package*.json ./
 
+# Inherit the same retry envs via ENV so npm ci below benefits from them too.
+ENV NPM_CONFIG_FETCH_RETRIES=5 \
+    NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=20000 \
+    NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=180000 \
+    NPM_CONFIG_FETCH_TIMEOUT=300000
+
 # Install production dependencies only
-RUN npm ci --only=production
+RUN npm ci --omit=dev || (echo "npm ci retry 1/2" && sleep 15 && npm ci --omit=dev) || (echo "npm ci retry 2/2" && sleep 45 && npm ci --omit=dev)
 
 # Copy Prisma schema, config, and generated client
 COPY --from=server-builder /app/prisma ./prisma


### PR DESCRIPTION
Closes #176

## Summary
Deploy-ubuntu failed on the post-merge run of PR #175 with `ECONNRESET` ~48s into `npm ci` in the client Docker build. npm's built-in per-request retries can't recover from a full connection drop mid-install.

- Set `NPM_CONFIG_FETCH_RETRIES=5` with generous min/max timeouts (20s/180s) and a 5-minute overall `FETCH_TIMEOUT` so individual package downloads self-heal.
- Wrap each `npm ci` with a 3-attempt shell retry (15s then 45s backoff) so a full connection reset still gets two more shots before the build fails.
- Applied to `client/Dockerfile` and both stages of `server/Dockerfile` (builder + production).
- Swap deprecated `--only=production` → `--omit=dev` on the prod install (was emitting a warning).

> **Note:** The retried build on top of this branch surfaced a separate TypeScript strict-mode failure in `MainLayout.tsx` — addressed in a follow-up PR so the two fixes stay independent.

## Test plan
- [ ] CI deploy-ubuntu run passes on this branch.
- [ ] Locally: `docker compose -f docker-compose.app.yml build` still succeeds (the retry path is a no-op on success).

🤖 Generated with [Claude Code](https://claude.com/claude-code)