### PR TITLE
fix(people): show person name in occupied-space chip, never raw UUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Occupied-space chip showed the wrong field** — when a person already held a space, the assignment dialog and selector chip displayed `Object.values(person.data)[0]`, which is whatever CSV column was first. For stores whose first column is e.g. "Title" (JMED) the chip showed "Doctor" instead of the person's name; when title was empty it fell through to the raw UUID. `SpaceSelectionDialog`, `SpaceSelector`, and the `personName` prop in `PeopleManagerView` now go through a new `getPersonDisplayName()` helper in `people/domain/types.ts` which resolves the name field from `solumMappingConfig.mappingInfo.articleName` (the same field the People table's Name column uses), falls back through `name`/`Name`/`NAME`/`fullName`, and finally to a translatable `people.unnamedPerson` label — never the UUID.
+
 ## [2.16.1] — 2026-04-26 — Labels Preview Images Fix
 
 > Client v2.16.1 / Server v2.11.0

--- a/src/features/people/domain/__tests__/types.test.ts
+++ b/src/features/people/domain/__tests__/types.test.ts
@@ -12,6 +12,7 @@ import {
     setPersonListMembership,
     removePersonFromList,
     getVirtualSpaceId,
+    getPersonDisplayName,
     toStorageName,
     toDisplayName,
     validateListName,
@@ -450,6 +451,63 @@ describe('People Domain Types', () => {
         it('should reject hyphen', () => {
             const result = validateListName('Team-Alpha');
             expect(result.valid).toBe(false);
+        });
+    });
+
+    describe('getPersonDisplayName', () => {
+        const fallback = 'Unnamed';
+
+        it('uses configured nameFieldKey when present and non-empty', () => {
+            const person: Person = {
+                id: 'p1',
+                data: { title: 'Doctor', fullName: 'Jane Doe' },
+            };
+            expect(getPersonDisplayName(person, 'fullName', fallback)).toBe('Jane Doe');
+        });
+
+        it('does not pick a different field even if it appears first in data', () => {
+            const person: Person = {
+                id: 'p1',
+                data: { title: 'Doctor', name: 'Alice' },
+            };
+            expect(getPersonDisplayName(person, 'name', fallback)).toBe('Alice');
+        });
+
+        it('falls back to common name keys when nameFieldKey is undefined', () => {
+            const person: Person = {
+                id: 'p1',
+                data: { title: 'Doctor', name: 'Bob' },
+            };
+            expect(getPersonDisplayName(person, undefined, fallback)).toBe('Bob');
+        });
+
+        it('falls back to common name keys when configured field is empty', () => {
+            const person: Person = {
+                id: 'p1',
+                data: { fullName: '', name: 'Carol' },
+            };
+            expect(getPersonDisplayName(person, 'fullName', fallback)).toBe('Carol');
+        });
+
+        it('returns fallback when no name fields have values, never the id', () => {
+            const person: Person = {
+                id: '8b4c2eaa-1234-5678-9abc-def012345678',
+                data: { title: 'Doctor', email: '' },
+            };
+            expect(getPersonDisplayName(person, undefined, fallback)).toBe(fallback);
+        });
+
+        it('treats whitespace-only values as empty', () => {
+            const person: Person = {
+                id: 'p1',
+                data: { fullName: '   ', name: 'Dan' },
+            };
+            expect(getPersonDisplayName(person, 'fullName', fallback)).toBe('Dan');
+        });
+
+        it('returns fallback for empty data object', () => {
+            const person: Person = { id: 'p1', data: {} };
+            expect(getPersonDisplayName(person, 'fullName', fallback)).toBe(fallback);
         });
     });
 });

--- a/src/features/people/domain/types.ts
+++ b/src/features/people/domain/types.ts
@@ -114,6 +114,30 @@ export function getVirtualSpaceId(person: Person): string {
     return person.virtualSpaceId || person.assignedSpaceId || person.id;
 }
 
+/**
+ * Resolve a person's user-facing display name.
+ *
+ * Mirrors the People table's Name column logic: prefers the field configured
+ * as the article-name in the SoluM mapping (settings.solumMappingConfig.mappingInfo.articleName),
+ * which is the same key the table shows. Falls back to common name keys for
+ * stores without a configured mapping. Never exposes the raw UUID.
+ */
+export function getPersonDisplayName(
+    person: Person,
+    nameFieldKey: string | undefined,
+    fallback: string,
+): string {
+    if (nameFieldKey) {
+        const v = person.data[nameFieldKey];
+        if (v && v.trim()) return v;
+    }
+    for (const key of ['name', 'Name', 'NAME', 'fullName']) {
+        const v = person.data[key];
+        if (v && v.trim()) return v;
+    }
+    return fallback;
+}
+
 export interface PeopleList {
     id: string;
     name: string;           // Display name (with spaces)

--- a/src/features/people/presentation/PeopleManagerView.tsx
+++ b/src/features/people/presentation/PeopleManagerView.tsx
@@ -37,6 +37,7 @@ import {
 } from './components';
 
 import type { Person, PeopleFilters } from '../domain/types';
+import { getPersonDisplayName } from '../domain/types';
 
 /**
  * People Manager View - Main component for managing people and space assignments
@@ -648,7 +649,7 @@ export function PeopleManagerView() {
                         }}
                         onSelect={handleSpaceSelected}
                         personId={spaceSelectPerson?.id || ''}
-                        personName={spaceSelectPerson ? Object.values(spaceSelectPerson.data)[0] : undefined}
+                        personName={spaceSelectPerson ? getPersonDisplayName(spaceSelectPerson, nameFieldKey, t('people.unnamedPerson')) : undefined}
                     />
                 )}
             </Suspense>

--- a/src/features/people/presentation/SpaceSelectionDialog.tsx
+++ b/src/features/people/presentation/SpaceSelectionDialog.tsx
@@ -14,6 +14,7 @@ import {
 import { useMemo, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePeopleStore } from '../infrastructure/peopleStore';
+import { getPersonDisplayName } from '../domain/types';
 import { useSettingsStore } from '@features/settings/infrastructure/settingsStore';
 import { useSpaceTypeLabels } from '@features/settings/hooks/useSpaceTypeLabels';
 
@@ -60,6 +61,8 @@ export function SpaceSelectionDialog({
     }, [t, getLabel]);
 
     const totalSpaces = settings.peopleManagerConfig?.totalSpaces || 0;
+    const nameFieldKey = settings.solumMappingConfig?.mappingInfo?.articleName;
+    const unnamedFallback = t('people.unnamedPerson');
     const [selectedSpaceId, setSelectedSpaceId] = useState<string | null>(null);
 
     // Determine text direction based on language
@@ -73,9 +76,10 @@ export function SpaceSelectionDialog({
         const assignedSpaces = new Map<string, string>();
         people.forEach(person => {
             if (person.assignedSpaceId && person.id !== personId) {
-                // Find person's display name for tooltip
-                const displayName = Object.values(person.data)[0] || person.id;
-                assignedSpaces.set(person.assignedSpaceId, displayName);
+                assignedSpaces.set(
+                    person.assignedSpaceId,
+                    getPersonDisplayName(person, nameFieldKey, unnamedFallback),
+                );
             }
         });
 
@@ -91,7 +95,7 @@ export function SpaceSelectionDialog({
         }
 
         return options;
-    }, [totalSpaces, people, personId]);
+    }, [totalSpaces, people, personId, nameFieldKey, unnamedFallback]);
 
     // Get available spaces count
     const availableCount = useMemo(() => {

--- a/src/features/people/presentation/SpaceSelector.tsx
+++ b/src/features/people/presentation/SpaceSelector.tsx
@@ -8,6 +8,7 @@ import {
 import { useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePeopleStore } from '../infrastructure/peopleStore';
+import { getPersonDisplayName } from '../domain/types';
 import { useSettingsStore } from '@features/settings/infrastructure/settingsStore';
 import { useSpaceTypeLabels } from '@features/settings/hooks/useSpaceTypeLabels';
 
@@ -61,6 +62,8 @@ export function SpaceSelector({
     }, [t, getLabel]);
 
     const totalSpaces = settings.peopleManagerConfig?.totalSpaces || 0;
+    const nameFieldKey = settings.solumMappingConfig?.mappingInfo?.articleName;
+    const unnamedFallback = t('people.unnamedPerson');
 
     // Determine text direction based on language
     const isRtl = i18n.language === 'he';
@@ -73,9 +76,10 @@ export function SpaceSelector({
         const assignedSpaces = new Map<string, string>();
         people.forEach(person => {
             if (person.assignedSpaceId && person.id !== excludePersonId) {
-                // Find person's display name for tooltip
-                const displayName = Object.values(person.data)[0] || person.id;
-                assignedSpaces.set(person.assignedSpaceId, displayName);
+                assignedSpaces.set(
+                    person.assignedSpaceId,
+                    getPersonDisplayName(person, nameFieldKey, unnamedFallback),
+                );
             }
         });
 
@@ -92,7 +96,7 @@ export function SpaceSelector({
         }
 
         return options;
-    }, [totalSpaces, people, excludePersonId, t]);
+    }, [totalSpaces, people, excludePersonId, t, nameFieldKey, unnamedFallback, tWithSpaceType]);
 
     // Find current selection
     const selectedOption = useMemo(() => {

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1380,6 +1380,7 @@
         "removeSelectedPeopleConfirm": "Are you sure you want to permanently delete {{count}} selected people? This action cannot be undone.",
         "id": "ID",
         "name": "Name",
+        "unnamedPerson": "Unnamed person",
         "assignedSpace": "Assigned {{spaceTypeSingular}}",
         "filterStatus": "Filter Status",
         "all": "All",

--- a/src/locales/he/common.json
+++ b/src/locales/he/common.json
@@ -1392,6 +1392,7 @@
         "removeSelectedPeopleConfirm": "האם אתה בטוח שברצונך למחוק לצמיתות {{count}} אנשים שנבחרו? לא ניתן לבטל פעולה זו.",
         "id": "מזהה",
         "name": "שם",
+        "unnamedPerson": "אדם ללא שם",
         "assignedSpace": "{{spaceTypeSingular}} מוקצה",
         "filterStatus": "סנן לפי סטטוס",
         "all": "הכל",


### PR DESCRIPTION
## Summary
- Side-button → "Assign space" dialog showed wrong field on occupied chips: in JMED prod it showed `Doctor` (first CSV column = title), and when title was empty it leaked the person's UUID.
- Root cause: three sites used `Object.values(person.data)[0] || person.id`. The People table itself avoids this by reading `person.data[settings.solumMappingConfig.mappingInfo.articleName]`.
- New `getPersonDisplayName(person, nameFieldKey, fallback)` helper in `people/domain/types.ts`. `SpaceSelectionDialog`, `SpaceSelector`, and the `personName` prop in `PeopleManagerView` now route through it.
- New i18n key `people.unnamedPerson` (EN: "Unnamed person", HE: "אדם ללא שם") used as the never-UUID fallback.

Closes #182

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/features/people/domain` — 53/53, 7 new
- [ ] Manual (prod): in JMED, open People → side button on a person → confirm occupied-space chips show people's names (not "Doctor"); confirm a person whose name field is empty shows "Unnamed person", not a UUID
- [ ] Manual (HE locale): chip shows "אדם ללא שם" when name is empty
- [ ] Manual: stores without `solumMappingConfig.mappingInfo.articleName` configured still show a sensible name (helper falls back to `name`/`fullName`/etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)