### PR TITLE
fix(people): broadcast people:changed on PATCH /people/:id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **People `PATCH` updates didn't push live to other clients** — `peopleController.create`, `delete`, `assign`, and `unassign` all called `sseManager.broadcastToStore` with a `people:changed` event, but the `update` handler at `server/src/features/people/controller.ts:104` did not. Editing a person's data (name, department, custom fields) updated the database and synced to AIMS, but other browsers in the same store kept showing the stale row until they manually refreshed or another mutation triggered a refetch. Added the missing broadcast with `action: 'update'`, mirroring the create-path payload and respecting `excludeClientId` so the originating client doesn't refetch unnecessarily. The client's `useStoreEvents` already calls `fetchPeople()` for any `people:changed` action, so no client change is needed.
+
 ## [2.16.1] — 2026-04-26 — Labels Preview Images Fix
 
 > Client v2.16.1 / Server v2.11.0

--- a/server/src/features/people/controller.ts
+++ b/server/src/features/people/controller.ts
@@ -110,9 +110,17 @@ export const peopleController = {
 
             const id = req.params.id as string;
             const user = getUserContext(req);
-            
+
             const result = await peopleService.update(id, validation.data, user);
             res.json(result);
+
+            // Broadcast people change to other clients
+            const sseClientId = req.headers['x-sse-client-id'] as string | undefined;
+            sseManager.broadcastToStore((result as any).storeId, {
+                type: 'people:changed',
+                payload: { action: 'update', personId: result.id },
+                excludeClientId: sseClientId,
+            });
         } catch (error: any) {
             if (error.message === 'NOT_FOUND') return next(notFound('Person'));
             next(error);


### PR DESCRIPTION
## Summary
- `peopleController.update` was the only people mutation not publishing `people:changed` over SSE — `create` / `delete` / `assign` / `unassign` all do.
- Result: a person edit (name, department, custom field) saved fine but other clients in the same store kept showing the stale row until something else triggered a refetch.
- One-block fix mirroring the create path: `sseManager.broadcastToStore(result.storeId, { type: 'people:changed', payload: { action: 'update', personId: result.id }, excludeClientId })`.
- No client change — `useStoreEvents` already calls `fetchPeople()` for any `people:changed` action.

Closes #184

Pairs with the prod NPM SSE fix from earlier today (real-time events now actually reach browsers in production).

## Test plan
- [x] `cd server && npx tsc --noEmit` clean
- [ ] Manual (two browsers, prod): user A edits a person → user B's row updates within ~1s without refresh
- [ ] Manual: originating browser does not double-refetch (excludeClientId honored)

## Note on tests
No controller-level test added — the existing create/delete/assign/unassign broadcasts have none either; the convention is service-layer tests only. Adding controller test infra for one line is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)