### PR TITLE
feat(spaces): SSE live updates on create/update/delete/bulk-delete/assignLabel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Spaces SSE live updates** — `spacesController` now publishes `spaces:changed` over the existing per-store SSE channel on `create`, `update`, `delete`, `bulk-delete`, and `assignLabel`, mirroring the conference/people pattern (`userName`, `excludeClientId`). Client-side `SpacesManagementView` mounts `useStoreEvents({ onSpacesChanged })`, so the spaces table now auto-refetches when another user mutates a space and shows a Snackbar with the originating user. The `useStoreEvents` hook already had the `spaces:changed` branch wired up but no consumer was mounting the hook on the spaces page. `spacesService.deleteBulk` now returns the unique `storeIds` of affected rows so the controller can broadcast once per store. Added test coverage for the new return shape and for cross-store dedup; existing deleteBulk tests updated for the new shape.
+
 ## [2.16.1] — 2026-04-26 — Labels Preview Images Fix
 
 > Client v2.16.1 / Server v2.11.0

--- a/server/src/features/spaces/__tests__/service.test.ts
+++ b/server/src/features/spaces/__tests__/service.test.ts
@@ -60,6 +60,7 @@ import { spacesService } from '../service.js';
 // ============================================================================
 
 const userInStore1 = { id: 'user-1', stores: [{ id: 'store-1' }], globalRole: 'USER' as any };
+const adminUser = { id: 'admin-1', stores: [], globalRole: 'PLATFORM_ADMIN' as any };
 
 beforeEach(() => {
     mockSpaceFindMany.mockReset();
@@ -90,7 +91,7 @@ describe('spacesService.deleteBulk', () => {
         expect(mockQueueDelete).toHaveBeenCalledWith('store-1', 'space', 'a', 'E-A');
         expect(mockQueueDelete).toHaveBeenCalledWith('store-1', 'space', 'b', 'E-B');
         expect(mockSpaceDeleteMany).toHaveBeenCalledWith({ where: { id: { in: ['a', 'b'] } } });
-        expect(result).toEqual({ deleted: ['a', 'b'], alreadyGone: [] });
+        expect(result).toEqual({ deleted: ['a', 'b'], alreadyGone: [], storeIds: ['store-1'] });
     });
 
     it('throws FORBIDDEN when an id belongs to a store the user cannot access', async () => {
@@ -117,14 +118,30 @@ describe('spacesService.deleteBulk', () => {
 
         const result = await spacesService.deleteBulk(['a', 'ghost'], userInStore1);
 
-        expect(result).toEqual({ deleted: ['a'], alreadyGone: ['ghost'] });
+        expect(result).toEqual({ deleted: ['a'], alreadyGone: ['ghost'], storeIds: ['store-1'] });
         expect(mockQueueDelete).toHaveBeenCalledTimes(1);
     });
 
     it('returns empty deleted with all-alreadyGone when no rows exist', async () => {
         mockSpaceFindMany.mockResolvedValue([]);
         const result = await spacesService.deleteBulk(['ghost1', 'ghost2'], userInStore1);
-        expect(result).toEqual({ deleted: [], alreadyGone: ['ghost1', 'ghost2'] });
+        expect(result).toEqual({ deleted: [], alreadyGone: ['ghost1', 'ghost2'], storeIds: [] });
         expect(mockTransaction).not.toHaveBeenCalled();
+    });
+
+    it('returns unique storeIds across multiple stores when all are accessible', async () => {
+        mockSpaceFindMany.mockResolvedValue([
+            { id: 'a', storeId: 'store-1', externalId: 'E-A', assignedLabels: [] },
+            { id: 'b', storeId: 'store-1', externalId: 'E-B', assignedLabels: [] },
+            { id: 'c', storeId: 'store-2', externalId: 'E-C', assignedLabels: [] },
+        ]);
+        mockTransaction.mockImplementation(async (fn: any) => {
+            return fn({ space: { deleteMany: mockSpaceDeleteMany } });
+        });
+        mockSpaceDeleteMany.mockResolvedValue({ count: 3 });
+
+        const result = await spacesService.deleteBulk(['a', 'b', 'c'], adminUser);
+
+        expect(result.storeIds.sort()).toEqual(['store-1', 'store-2']);
     });
 });

--- a/server/src/features/spaces/controller.ts
+++ b/server/src/features/spaces/controller.ts
@@ -9,9 +9,14 @@ import { spacesService } from './service.js';
 import { spacesSyncService } from './syncService.js';
 import { createSpaceSchema, updateSpaceSchema, assignLabelSchema, bulkDeleteSpacesSchema } from './types.js';
 import type { SpacesUserContext } from './types.js';
+import { sseManager } from '../../shared/infrastructure/sse/SseManager.js';
 
 function getUserContext(req: Request): SpacesUserContext {
     return { id: req.user!.id, globalRole: req.user?.globalRole, stores: req.user?.stores?.map(s => ({ id: s.id })) };
+}
+
+function getSseClientId(req: Request): string | undefined {
+    return req.headers['x-sse-client-id'] as string | undefined;
 }
 
 export const spacesController = {
@@ -46,9 +51,21 @@ export const spacesController = {
 
     async create(req: Request, res: Response, next: NextFunction) {
         try {
+            const user = getUserContext(req);
             const data = createSpaceSchema.parse(req.body);
-            const result = await spacesService.create(data, getUserContext(req));
+            const result = await spacesService.create(data, user);
             res.status(201).json(result);
+
+            sseManager.broadcastToStore(result.storeId, {
+                type: 'spaces:changed',
+                payload: {
+                    action: 'create',
+                    spaceId: result.id,
+                    externalId: result.externalId,
+                    userName: req.user?.email || 'Unknown',
+                },
+                excludeClientId: getSseClientId(req),
+            });
         } catch (error: any) {
             if (error.message === 'FORBIDDEN') return next(forbidden('Access denied to this store'));
             if (error.message === 'CONFLICT') return next(conflict('Space with this ID already exists'));
@@ -61,6 +78,17 @@ export const spacesController = {
             const data = updateSpaceSchema.parse(req.body);
             const result = await spacesService.update(req.params.id as string, data, getUserContext(req));
             res.json(result);
+
+            sseManager.broadcastToStore(result.storeId, {
+                type: 'spaces:changed',
+                payload: {
+                    action: 'update',
+                    spaceId: result.id,
+                    externalId: result.externalId,
+                    userName: req.user?.email || 'Unknown',
+                },
+                excludeClientId: getSseClientId(req),
+            });
         } catch (error: any) {
             if (error.message === 'NOT_FOUND') return next(notFound('Space'));
             next(error);
@@ -69,8 +97,32 @@ export const spacesController = {
 
     async delete(req: Request, res: Response, next: NextFunction) {
         try {
-            await spacesService.delete(req.params.id as string, getUserContext(req));
+            const id = req.params.id as string;
+            const user = getUserContext(req);
+
+            // Get storeId before deletion (for SSE broadcast)
+            let existing: any = null;
+            try {
+                existing = await spacesService.getById(id, user);
+            } catch {
+                // Fall through; spacesService.delete will throw NOT_FOUND
+            }
+
+            await spacesService.delete(id, user);
             res.status(204).send();
+
+            if (existing) {
+                sseManager.broadcastToStore(existing.storeId, {
+                    type: 'spaces:changed',
+                    payload: {
+                        action: 'delete',
+                        spaceId: id,
+                        externalId: existing.externalId,
+                        userName: req.user?.email || 'Unknown',
+                    },
+                    excludeClientId: getSseClientId(req),
+                });
+            }
         } catch (error: any) {
             if (error.message === 'NOT_FOUND') return next(notFound('Space'));
             next(error);
@@ -82,6 +134,17 @@ export const spacesController = {
             const { ids } = bulkDeleteSpacesSchema.parse(req.body);
             const result = await spacesService.deleteBulk(ids, getUserContext(req));
             res.json(result);
+
+            // One broadcast per affected store; payload tells clients to refetch
+            const sseClientId = getSseClientId(req);
+            const userName = req.user?.email || 'Unknown';
+            for (const storeId of result.storeIds) {
+                sseManager.broadcastToStore(storeId, {
+                    type: 'spaces:changed',
+                    payload: { action: 'bulk-delete', count: result.deleted.length, userName },
+                    excludeClientId: sseClientId,
+                });
+            }
         } catch (error: any) {
             if (error.message === 'FORBIDDEN') {
                 return next(forbidden('One or more spaces belong to a store you cannot access'));
@@ -95,6 +158,18 @@ export const spacesController = {
             const { labelCode } = assignLabelSchema.parse(req.body);
             const result = await spacesService.assignLabel(req.params.id as string, labelCode, getUserContext(req));
             res.json(result);
+
+            sseManager.broadcastToStore(result.storeId, {
+                type: 'spaces:changed',
+                payload: {
+                    action: 'assign-label',
+                    spaceId: result.id,
+                    externalId: result.externalId,
+                    labelCode,
+                    userName: req.user?.email || 'Unknown',
+                },
+                excludeClientId: getSseClientId(req),
+            });
         } catch (error: any) {
             if (error.message === 'NOT_FOUND') return next(notFound('Space'));
             if (error.message === 'LABEL_IN_USE') return next(conflict('Label is already assigned to another space'));

--- a/server/src/features/spaces/service.ts
+++ b/server/src/features/spaces/service.ts
@@ -143,7 +143,7 @@ export const spacesService = {
                 alreadyGone: alreadyGone.length,
                 triggeredBy: user.id,
             });
-            return { deleted: [] as string[], alreadyGone };
+            return { deleted: [] as string[], alreadyGone, storeIds: [] as string[] };
         }
 
         await prisma.$transaction(async (tx) => {
@@ -168,7 +168,8 @@ export const spacesService = {
             triggeredBy: user.id,
         });
 
-        return { deleted: accessible.map((a) => a.id), alreadyGone };
+        const affectedStoreIds = Array.from(new Set(accessible.map((a) => a.storeId)));
+        return { deleted: accessible.map((a) => a.id), alreadyGone, storeIds: affectedStoreIds };
     },
 
     async assignLabel(id: string, labelCode: string, user: SpacesUserContext) {

--- a/src/features/space/presentation/SpacesManagementView.tsx
+++ b/src/features/space/presentation/SpacesManagementView.tsx
@@ -18,6 +18,8 @@ import {
     Badge,
     alpha,
     Checkbox,
+    Snackbar,
+    Alert,
 } from '@mui/material';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
@@ -46,6 +48,7 @@ import { useSpaceTypeLabels } from '@features/settings/hooks/useSpaceTypeLabels'
 import type { Space } from '@shared/domain/types';
 import { useConfirmDialog } from '@shared/presentation/hooks/useConfirmDialog';
 import { useUnsavedListGuard } from '@shared/presentation/hooks/useUnsavedListGuard';
+import { useStoreEvents } from '@shared/presentation/hooks/useStoreEvents';
 import { useSpacesStore } from '@features/space/infrastructure/spacesStore';
 import { useAuthStore } from '@features/auth/infrastructure/authStore';
 import { useAuthContext } from '@features/auth/application/useAuthContext';
@@ -336,6 +339,19 @@ export function SpacesManagementView() {
             }
         }
     }, [activeListName, activeListId, lists]);
+
+    // SSE real-time sync — auto-refetch happens inside the hook on spaces:changed.
+    // Toast lets the user know who triggered the change.
+    const [sseAlert, setSseAlert] = useState<string | null>(null);
+    useStoreEvents({
+        onSpacesChanged: (event) => {
+            const user = event.userName || t('common.anotherUser', { defaultValue: 'Another user' });
+            setSseAlert(t('spaces.spacesChangedByOther', {
+                defaultValue: '{{user}} updated spaces',
+                user,
+            }));
+        },
+    });
 
     // Get sync context for triggering push after CRUD operations
     const { push } = useBackendSyncContext();
@@ -1109,6 +1125,23 @@ export function SpacesManagementView() {
                     />
                 )}
             </Suspense>
+
+            {/* SSE alert — spaces changed by another user */}
+            <Snackbar
+                open={!!sseAlert}
+                autoHideDuration={5000}
+                onClose={() => setSseAlert(null)}
+                anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+            >
+                <Alert
+                    onClose={() => setSseAlert(null)}
+                    severity="info"
+                    variant="filled"
+                    sx={{ width: '100%' }}
+                >
+                    {sseAlert}
+                </Alert>
+            </Snackbar>
         </Box>
         </PullToRefresh>
     );

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -362,6 +362,7 @@
     "spaces": {
         "title": "Spaces",
         "manage": "Manage your spaces and label assignments",
+        "spacesChangedByOther": "{{user}} updated spaces",
         "addSpace": "Add Space",
         "editSpace": "Edit Space",
         "deleteSpace": "Delete Space",

--- a/src/locales/he/common.json
+++ b/src/locales/he/common.json
@@ -365,6 +365,7 @@
     "spaces": {
         "title": "חללים",
         "manage": "נהל את החללים ושיוכי התגיות שלך",
+        "spacesChangedByOther": "{{user}} עדכן/ה חללים",
         "addSpace": "הוסף חלל",
         "editSpace": "ערוך חלל",
         "deleteSpace": "מחק חלל",

--- a/src/shared/infrastructure/services/storeEventsService.ts
+++ b/src/shared/infrastructure/services/storeEventsService.ts
@@ -16,10 +16,14 @@ export type StoreEventType = 'connected' | 'people:changed' | 'spaces:changed' |
 export interface StoreEvent {
     type: StoreEventType;
     timestamp: string;
-    // people:changed, conference:changed
-    action?: 'create' | 'delete' | 'assign' | 'unassign' | 'update' | 'toggle' | 'page-flip';
+    // people:changed, conference:changed, spaces:changed
+    action?: 'create' | 'delete' | 'assign' | 'unassign' | 'update' | 'toggle' | 'page-flip' | 'assign-label' | 'bulk-delete';
     personId?: string;
     spaceId?: string;
+    // spaces:changed
+    externalId?: string;
+    labelCode?: string;
+    count?: number;
     // list:loaded
     listId?: string;
     listName?: string;


### PR DESCRIPTION
## Summary
- Server: `spacesController` now publishes `spaces:changed` over the existing per-store SSE channel on `create`, `update`, `delete`, `deleteBulk`, and `assignLabel`. Mirrors the conference payload shape (`userName`, `externalId`, `excludeClientId`).
- Client: `SpacesManagementView` now mounts `useStoreEvents({ onSpacesChanged })`. The hook already auto-refetches `fetchSpaces()` on `spaces:changed` — adding it here was the missing wire. Snackbar credits the originating user.
- `spacesService.deleteBulk` now returns the unique `storeIds` of affected rows so the controller can broadcast once per store; existing tests updated for the new return shape, plus a new test for cross-store dedup.

Closes #186

Pairs with the prod NPM SSE buffering fix from earlier today (real events now actually reach prod) and #184 (people PATCH broadcast).

## Test plan
- [x] `cd server && npx tsc --noEmit` clean
- [x] `npx tsc --noEmit` clean
- [x] `cd server && npx vitest run src/features/spaces` — 10/10
- [x] `npx vitest run src/features/space src/shared` — 522 pass; 13 fails in `NavigationDrawer.test.tsx` are pre-existing on `main`, unrelated
- [ ] Manual (two browsers, prod, same store): user A creates / edits / deletes / bulk-deletes / assigns-label → user B's spaces table refetches and shows Snackbar within ~1s
- [ ] Manual: originating browser does not double-refetch (excludeClientId honored)

## Notes
- `useStoreEvents` mounts SSE only while a consuming component is alive. Spaces page now mounts it; People and Conference already do. Adding the page-scoped consumer is intentional — we don't want spaces to refetch while users are on Labels or Settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)